### PR TITLE
Add DataJoint 2.0 example analyzing relational workflow model vs STAMPED

### DIFF
--- a/content/examples/datajoint-relational-workflow.md
+++ b/content/examples/datajoint-relational-workflow.md
@@ -1,0 +1,194 @@
+---
+title: "DataJoint 2.0: Relational Workflow Model as Computational Substrate"
+date: 2026-02-19
+description: "How DataJoint 2.0's relational workflow model addresses STAMPED properties through database-native workflow specification"
+summary: "Examines DataJoint 2.0's approach where tables represent workflow steps, rows represent artifacts, and foreign keys prescribe execution order — a fundamentally different path to STAMPED properties than file-based version control."
+tags: ["datajoint", "relational-database", "provenance", "workflow", "sciops"]
+stamped_principles: ["A", "T", "M"]
+fair_principles: ["I", "R"]
+instrumentation_levels: ["pattern"]
+aspirations: ["reproducibility", "rigor", "efficiency"]
+state: uncurated-ai
+params:
+  tools: ["datajoint", "mysql", "python"]
+  difficulty: "advanced"
+  verified: false
+---
+
+{{< alert >}}
+Based on [Yatsenko & Nguyen 2026, arXiv:2602.16585](https://arxiv.org/abs/2602.16585).
+{{< /alert >}}
+
+## A different path to the same goals
+
+Most examples on this site approach STAMPED properties through file-based version
+control — git repositories, content-addressed storage, recorded shell commands.
+DataJoint 2.0 takes a fundamentally different path: the **relational database
+itself** becomes the workflow specification, provenance record, and execution
+coordinator.
+
+The core idea is the **relational workflow model**: tables represent workflow
+steps, rows represent artifacts, and foreign keys prescribe execution order. The
+schema specifies not only what data exists but *how data is derived*.
+
+This makes DataJoint an instructive contrast case — it achieves some STAMPED
+properties very naturally while approaching others in ways that differ sharply
+from the git-based tooling emphasized elsewhere on this site.
+
+## How DataJoint maps to STAMPED
+
+### Actionable — a natural strength
+
+Actionability is where DataJoint's approach excels. In a DataJoint pipeline,
+each Computed table declares a `make()` method that specifies exactly how its
+contents are derived from upstream tables:
+
+```python
+@schema
+class MotionEnergy(dj.Computed):
+    definition = """
+    -> VideoRecording
+    ---
+    motion_energy : longblob
+    """
+
+    def make(self, key):
+        video = (VideoRecording & key).fetch1("video_path")
+        energy = compute_motion_energy(video)
+        self.insert1({**key, "motion_energy": energy})
+```
+
+The schema *is* the executable specification. There is no separate workflow file,
+no README describing what to run — the table definition and its `make()` method
+are one unit. Calling `MotionEnergy.populate()` automatically identifies which
+upstream rows lack a corresponding derived row and executes `make()` for each.
+
+This achieves actionability at a structural level: the system cannot represent a
+computation without also specifying how to perform it.
+
+### Tracked — provenance through relational structure
+
+DataJoint's tracking model differs from git-based provenance. Rather than
+recording shell commands in commit messages (as `datalad run` does), DataJoint
+embeds provenance in the relational structure itself:
+
+- **Foreign keys** encode the dependency graph — every computed result points
+  back to the specific input rows that produced it.
+- **Job tables** record which worker computed each result, when, and whether
+  errors occurred.
+- **Entity normalization** ensures each table represents artifacts from a single
+  workflow step, so provenance is unambiguous.
+
+The **workflow normalization principle** extends database normalization to
+computation: "Every table represents an entity type created at a specific
+workflow step, and all attributes describe that entity as it exists at that
+step." This prevents "kitchen sink" tables that accumulate attributes from
+different stages, obscuring provenance.
+
+DataJoint 2.0 adds **semantic matching** — attributes match in joins only if
+they share a common ancestor in the foreign key lineage graph, preventing silent
+data corruption from homonymous but unrelated columns.
+
+However, DataJoint does not provide content-addressed identification of the
+sort that git offers. Two DataJoint databases with identical logical content are
+not provably identical via a hash comparison. Version tracking is structural
+(the schema and foreign keys) rather than content-addressed.
+
+### Modular — reusable schema components
+
+DataJoint Elements provide reusable schema modules for common experimental
+modalities — electrophysiology, calcium imaging, behavioral tracking. These
+modules:
+
+- Can be adopted independently across research groups
+- Maintain consistent data architecture without prescribing analysis choices
+- Compose via foreign key relationships into larger pipelines
+
+The **master-part relationship** provides atomic composition: a workflow step
+producing multiple related items (e.g., a spike-sorting run producing per-unit
+waveforms) inserts and deletes as a unit.
+
+This mirrors STAMPED modularity's goal of independently versioned, reusable
+components, achieved through schema composition rather than git submodules.
+
+### Self-contained — within the database boundary
+
+DataJoint 2.0's **Object-Augmented Schema (OAS)** integrates relational metadata
+with object storage under unified transactional control. Deleting a record
+cascades to dependent tables *and* removes associated objects. This prevents the
+orphaned-file problem that plagues systems storing file paths in database columns.
+
+A DataJoint pipeline project is a standard Python package containing schema
+definitions, computation logic, and configuration. In this sense, the code
+repository + database together form a self-contained unit.
+
+However, the self-containment boundary differs from STAMPED's "don't look up"
+rule. A DataJoint pipeline depends on an external database server and object
+store — infrastructure that is not carried within the research object itself.
+The schema is portable; the running system is not.
+
+### Portable — types yes, infrastructure less so
+
+DataJoint 2.0's three-layer type system addresses data portability:
+- **Core types** (int64, float64, varchar, datetime) have consistent semantics
+  across MySQL and PostgreSQL.
+- **Codec types** provide extensible serialization with lazy loading.
+- **Schema-addressed storage** organizes objects in paths mirroring primary key
+  structure, enabling filesystem navigation without database queries.
+
+Procedures are defined in Python, not in database-specific SQL, improving code
+portability. But the system requires a relational database backend — moving a
+DataJoint pipeline between environments requires provisioning database
+infrastructure, unlike copying a git repository.
+
+### Ephemeral — workers yes, database no
+
+DataJoint's distributed job coordination supports ephemeral workers: each
+computational job runs independently, workers can be created and destroyed
+freely, and `populate()` is idempotent — retrying after failure produces no side
+effects. This pattern enables scaling across disposable cloud instances.
+
+However, the central database is not ephemeral — it is the persistent substrate.
+This contrasts with STAMPED's vision where the entire research object can be
+rebuilt in a fresh, disposable environment. DataJoint can re-derive all computed
+results from manual/imported data, but the database must persist.
+
+### Distributable — centralized by design
+
+DataJoint's architecture is explicitly centralized: a shared database server
+coordinates all access. This is a deliberate design choice enabling transactional
+guarantees and referential integrity, but it contrasts with STAMPED's emphasis
+on decentralized distribution (cloning, forking, pushing, pulling).
+
+Schema-addressed storage and standard SQL tables mean data *can* be exported
+and shared, but the operational model assumes a central database, not peer-to-peer
+replication.
+
+## What DataJoint teaches about STAMPED
+
+DataJoint demonstrates that STAMPED properties can be approached from
+fundamentally different architectural starting points:
+
+| STAMPED property | Git-based approach | DataJoint approach |
+|---|---|---|
+| Self-contained | Everything in the repo | Schema + OAS within the database |
+| Tracked | Content-addressed VCS | Relational structure + foreign keys |
+| Actionable | Recorded shell commands | Declarative `make()` methods |
+| Modular | Git submodules / subdatasets | Schema composition via Elements |
+| Portable | Backend-agnostic file layout | Portable types, DB-dependent infra |
+| Ephemeral | Rebuild from fresh clone | Ephemeral workers, persistent DB |
+| Distributable | Clone / fork / push / pull | Centralized DB, export for sharing |
+
+The strongest alignment is on **Actionability** — DataJoint's `make()` methods
+are arguably *more* actionable than file-based provenance because the executable
+specification is structurally inseparable from the data definition.
+
+The sharpest divergence is on **Distributability** — DataJoint's centralized
+architecture trades decentralization for transactional guarantees and referential
+integrity, a different set of priorities than distributed VCS.
+
+## Further reading
+
+- [Yatsenko & Nguyen 2026](https://arxiv.org/abs/2602.16585) — DataJoint 2.0: A Computational Substrate for Agentic Scientific Workflows
+- [DataJoint documentation](https://datajoint.com/docs)
+- [DataJoint Elements](https://datajoint.com/docs/elements/) — reusable schema modules for neurophysiology


### PR DESCRIPTION
Based on Yatsenko & Nguyen 2026 (arXiv:2602.16585) alerted to by @dimitri-yatsenko in relation to sciops paper draft.

Crafted by claude-code, so `uncrated-ai` label -- mostly even for intro to myself.

Examines how DataJoint's relational workflow model — where tables are workflow steps, rows are artifacts, and foreign keys prescribe execution order — maps to each STAMPED property. Strongest alignment on Actionability (make() methods as structural executable specs), sharpest divergence on Distributability (centralized DB vs decentralized VCS).