### PR TITLE
Add ephemeral shell reproducer example

### DIFF
--- a/content/examples/ephemeral-shell-reproducer.md
+++ b/content/examples/ephemeral-shell-reproducer.md
@@ -189,6 +189,9 @@ makes it "green", and the test prevents regressions.
 
 ## Example scenarios
 
+
+TODO: rework examples as a spectrum of STAMPED scenarios - from a simple self-contained script to a script producing a STAMPED object with its own provenance etc recorded; to the one including container one way or another; to the one modularly including some other module (like ///repronim/containers) or some original "sub-dataset".  I think  for container we could use some basic lolcow container which would produce us a nice "asciiart!"
+
 ### Scenario 1: git-annex fails to sync unlocked file content
 
 A user reports that after unlocking a file, modifying it, and committing, `git


### PR DESCRIPTION
Pattern distilled from 140+ scripts in @yarikoptic's `datalad/trash/`: minimal POSIX shell scripts that create a temp directory, set up state from scratch, trigger a bug, and can be thrown away. Covers set -eu, set -x/PS4 for reproducible traces, mktemp -d for security, subshell isolation, and expected-failure guards. Includes three concrete scenarios and practical guidelines.

As distilled from datalad ones, examples are datalad specific -- later we might want to extend or better replace with some examples from other domains.