### PR TITLE
Stellar distance STAMPED walkthrough example

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,7 +1,11 @@
 name: Deploy Hugo site to GitHub Pages
 
+# Run after Test succeeds on main so the step-map notes pushed by
+# materialize_examples --strict --push are available for the deploy.
 on:
-  push:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
     branches: ["main"]
   workflow_dispatch:
 
@@ -21,6 +25,8 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Only deploy on successful Test runs (or manual dispatch).
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     env:
       HUGO_VERSION: "0.153.0"
     steps:
@@ -37,6 +43,14 @@ jobs:
 
       - name: Fetch theme submodule
         run: git submodule update --init themes/congo
+
+      - name: Fetch materialized example branches and step-map notes
+        run: |
+          git fetch origin 'refs/heads/examples/*:refs/heads/examples/*' || true
+          git fetch origin 'refs/notes/materialize-step-map:refs/notes/materialize-step-map' || true
+
+      - name: Export step maps to data/ for Hugo
+        run: python3 scripts/materialize_examples --export-data-from-notes
 
       - name: Setup Pages
         id: pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install tox
         run: pip install tox
 
+      - name: Install DataLad and pip-tools
+        run: pip install datalad pip-tools requests
+
       - name: Install Hugo
         env:
           HUGO_VERSION: "0.153.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,8 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install tox
-        run: pip install tox
-
-      - name: Install DataLad and pip-tools
-        run: pip install datalad pip-tools requests
+      - name: Install tox and test requirements
+        run: pip install tox -r requirements-test.txt
 
       - name: Install Hugo
         env:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,14 @@ test-snippets:
 test-hugo:
 	hugo --gc --minify
 
+materialize:
+	tox -e materialize
+
+rematerialize:
+	tox -e rematerialize
+
 clean:
 	rm -f $(STAMPED_MD) $(STAMPED_PDF)
 	rm -rf public/
 
-.PHONY: all serve-devel pdf clean test test-snippets test-hugo
+.PHONY: all serve-devel pdf clean test test-snippets test-hugo materialize rematerialize

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -238,6 +238,17 @@ a[href*="/aspirations/"].rounded-md:hover {
   color: #ffffff;
 }
 
+/* ── hidden: dashed purple (only visible with HUGO_SHOW_HIDDEN) ── */
+.codeblock-hidden {
+  border-left-color: #7c3aed;
+  border-left-style: dashed;
+  opacity: 0.7;
+}
+.codeblock-hidden .codeblock-label {
+  background-color: #7c3aed;
+  color: #ffffff;
+}
+
 /* ── example branch links ────────────────────────────────── */
 .example-branch-links {
   margin-top: -0.75rem;

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -8,6 +8,10 @@ defaultContentLanguage = "en"
 enableRobotsTXT = true
 summaryLength = 0
 
+# Author-side metadata files in content/ (e.g. .steps.json sidecars consumed
+# by scripts/materialize_examples) — not user-facing, do not publish.
+ignoreFiles = ['\.steps\.json$']
+
 [pagination]
   pagerSize = 20
 

--- a/conftest.py
+++ b/conftest.py
@@ -17,20 +17,43 @@ import pytest
 from sybil import Document, Region, Sybil
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / "scripts"))
-from snippet_parser import FENCE_RE, parse_pragmas
+from snippet_parser import FENCE_RE, _merge_pragmas, parse_pragmas
 
 
 def shell_script_parser(document: Document):
-    """Find ``sh`` code blocks containing ``# pragma: testrun`` and yield Regions."""
+    """Find ``sh`` code blocks containing ``# pragma: testrun`` and yield Regions.
+
+    Multiple blocks sharing the same ``testrun`` ID are concatenated
+    (in document order) into a single Region so they execute as one script.
+    """
+    groups: dict[str, dict] = {}
+    order: list[str] = []
+
     for m in FENCE_RE.finditer(document.text):
         code = m.group(1)
         if "# pragma: testrun" not in code:
             continue
         pragmas = parse_pragmas(code)
+        testrun_id = pragmas.get("testrun", "unnamed")
+
+        if testrun_id not in groups:
+            groups[testrun_id] = {
+                "codes": [], "pragmas": {},
+                "start": m.start(), "end": m.end(),
+            }
+            order.append(testrun_id)
+
+        groups[testrun_id]["codes"].append(code)
+        groups[testrun_id]["end"] = m.end()
+        _merge_pragmas(groups[testrun_id]["pragmas"], pragmas)
+
+    for testrun_id in order:
+        group = groups[testrun_id]
+        combined = "\n".join(group["codes"])
         yield Region(
-            start=m.start(),
-            end=m.end(),
-            parsed={"code": code, "pragmas": pragmas},
+            start=group["start"],
+            end=group["end"],
+            parsed={"code": combined, "pragmas": group["pragmas"]},
             evaluator=evaluate_shell_script,
         )
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -1,7 +1,7 @@
 ---
 title: "Walkthrough: stellar distances from Gaia parallax"
 date: 2026-03-12
-description: "A step-by-step walkthrough building a STAMPED research object that computes stellar distances from Gaia DR3 parallax data"
+description: "Building a STAMPED research object that computes stellar distances from Gaia DR3 parallax data"
 summary: "Incrementally builds a research object from a bare script to a tracked, portable, reproducible pipeline — motivated by real problems, not by acronym order."
 tags: ["gaia", "parallax", "walkthrough", "python", "datalad", "make"]
 stamped_principles: ["S", "T", "A", "M", "P", "E", "D"]
@@ -19,13 +19,13 @@ params:
 Most research code starts the same way: a script that works, on your machine, right now.
 That's not a problem — it's a starting point.
 
-In this walkthrough we take a real analysis — computing distances to nearby stars from European Space Agency data — and turn it into something anyone can verify, reproduce, and build on.
-No new frameworks to learn.
+Here we take a real analysis — computing distances to nearby stars from European Space Agency data — and gradually turn it into something anyone can verify, reproduce, and build on.
+No new frameworks.
 No heavyweight infrastructure.
-Just a series of small, practical steps, each one solving a concrete problem you've probably already run into: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
+Just a series of small, practical steps, each one solving a concrete problem: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
 
-Along the way, we'll point out which STAMPED properties each step improves.
-By the end, you'll have a research object that passes a from-scratch reproduction test in a throwaway directory — and you'll see that most of the steps are things you might already be doing, just named and organized.
+Along the way, we note which STAMPED properties each step improves.
+By the end, we have a research object that passes a from-scratch reproduction test in a throwaway directory — and most of the steps turn out to be things we might already be doing, just named and organized.
 
 **The science**: we compute the distance to 100 nearby stars using parallax measurements from the [Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
 The math is one line: `distance_pc = 1000 / parallax_mas`.
@@ -39,44 +39,38 @@ The analysis is deliberately simple so the focus stays on *how* we organize, tra
 
 ### 1. Proof of concept
 
-Write a single Python script that queries the Gaia TAP API, fetches parallax for 100 nearby stars, computes `distance_pc = 1000 / parallax`, and writes a CSV.
-Run it.
-Get a result.
-Done.
+We start with a single Python script that queries the Gaia TAP API, fetches parallax for 100 nearby stars, computes `distance_pc = 1000 / parallax`, and writes a CSV.
+Run it, get a result, done.
 
 This is where most analyses live forever — and that's fine for exploration.
-But what happens when you come back in six months and can't remember which query parameters you used?
-When a collaborator asks "how do I run this?" and the answer is "well, first you need to install..."?
-When a reviewer asks you to recompute with updated data?
+But what happens when we come back in six months and can't remember which query parameters we used?
+When a collaborator asks "how do I run this?"
+When a reviewer asks us to recompute with updated data?
 
 Each step that follows addresses one of these failure modes.
 
-*We committed this so you can see it, but in real life this might just be a loose file on your desktop.*
+*We committed this so it's visible in the repo, but in real life this might just be a loose file on the desktop.*
 
 **Commit**: [`0d95ecc`](0d95ecc)
 
 ### 2. Gather everything under one roof
 
-Put all files in a single project directory.
+We put all the files in a single project directory.
 
 This sounds obvious, but it's the foundation everything else builds on.
-Right now the script and its output are loose files — a collaborator would need to know which ones go together.
-A project directory draws a boundary: everything inside is part of this work, and nothing outside should be needed.
+Right now the script and its output are loose — a collaborator would need to know which ones go together.
+A project directory draws a boundary: everything inside is part of this work, nothing outside should be needed.
 STAMPED calls this the "don't look up" rule (S.1): a research object must never rely on implicit external state.
 
 **Advances**: S (everything reachable from one root)
 
 ### 3. Organize into directories
 
-Separate `code/`, `raw/`, `output/`.
-Code is what you write.
-Raw is what you fetch.
-Output is what you compute.
+We separate `code/`, `raw/`, and `output/`, and split the monolithic script into two: one that fetches data, one that computes distances.
 
-This tells you the role of each file at a glance.
-When something breaks, you know where to look.
-We also split the monolithic script into two: one that fetches data, one that computes distances.
-Each piece is now independently testable and replaceable — Modularity at its simplest.
+Now the role of each file is obvious at a glance — code is what we write, raw is what we fetch, output is what we compute.
+When something breaks, we know where to look.
+And each piece is independently testable and replaceable — Modularity at its simplest.
 
 **Advances**: M (logical separation of concerns), S (clearer boundary)
 
@@ -84,9 +78,9 @@ Each piece is now independently testable and replaceable — Modularity at its s
 
 ### 4. Write a README
 
-Explain what this project does, what the inputs and outputs are, and how to run it.
+We add a README explaining what this project does, what the inputs and outputs are, and how to run it.
 
-Without a README, the project is only usable by the person who wrote it — and only while they remember how.
+Without one, the project is only usable by the person who wrote it — and only while they remember how.
 A README makes it usable by anyone who can read.
 This is the minimum viable Actionability (A.1): sufficient instructions to reproduce all results.
 
@@ -96,21 +90,21 @@ This is the minimum viable Actionability (A.1): sufficient instructions to repro
 
 ### 5. Initialize version control
 
-`git init`. Add everything. First commit.
+`git init`, add everything, first commit.
 
-From now on, every change is recorded: who, when, what, and (in the commit message) why.
-You can always get back to any previous state.
+From now on every change is recorded: who, when, what, and (in the commit message) why.
+We can always get back to any previous state.
 
-Each commit hash is a fingerprint of the entire project state — not a label like "version 1.0" that two people could apply to different things, but a cryptographic checksum that two people with the same hash provably have the same content.
-Version control is also the safety net that makes every subsequent step low-risk: if something goes wrong, you can always revert.
+Each commit hash is a fingerprint of the entire project state — not a label like "version 1.0" that two people could apply to different things, but a cryptographic checksum where the same hash means provably the same content.
+This is also the safety net that makes every subsequent step low-risk: if something goes wrong, we revert.
 
 **Advances**: T (content identification, change history)
 
-*In the companion repository, we initialized git from the start so each step has its own commit. In your own work, this is the point where you'd run `git init`.*
+*In the companion repository we initialized git from the start so each step has its own commit. In practice, this is the point where we'd run `git init`.*
 
 ### 6. Write a Makefile
 
-Encode the pipeline as `make` targets: `raw/gaia_nearby.csv` depends on `code/fetch_data.py`, `output/distances.csv` depends on `raw/gaia_nearby.csv` and `code/compute_distances.py`.
+We encode the pipeline as `make` targets: `raw/gaia_nearby.csv` depends on `code/fetch_data.py`, `output/distances.csv` depends on the raw data and `code/compute_distances.py`.
 `make` runs the whole thing.
 
 The README *says* how to run the pipeline.
@@ -124,14 +118,14 @@ Make also encodes dependencies: it knows what to re-run when an input changes, w
 
 ### 7. Add a test
 
-Write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
+We write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
 `make test` runs it.
-48 of 100 stars have reference values; all match within 0.3%.
+48 of our 100 stars have reference values; all match within 0.3%.
 
-A research object without verification asks others to trust the results.
+Without verification, a research object asks others to trust the results.
 A test makes the claim falsifiable — anyone can run `make test` and see for themselves.
 
-An interesting detail: only 48 of our 100 stars have GSP-Phot distances, because Gaia's sophisticated pipeline doesn't produce estimates for every star.
+An interesting detail: only 48 stars have GSP-Phot distances because Gaia's sophisticated pipeline doesn't produce estimates for every star.
 Our simple one-line formula actually covers more stars than the pipeline does.
 
 **Advances**: A (verifiable results, not just "trust me")
@@ -140,9 +134,9 @@ Our simple one-line formula actually covers more stars than the pipeline does.
 
 ### 8. Declare dependencies
 
-Add `pyproject.toml` listing the Python packages we use (`requests`).
+We add `pyproject.toml` listing the Python packages we use.
 
-Until now, the scripts used only Python's standard library.
+Until now the scripts used only Python's standard library.
 When we rewrote the fetch script to use `requests` (cleaner API, better error handling), we introduced an external dependency.
 Without declaring it, a fresh machine fails with `ModuleNotFoundError: No module named 'requests'` — a Portability failure that only surfaces when someone else tries to run the code.
 `pyproject.toml` makes that assumption explicit.
@@ -153,12 +147,12 @@ Without declaring it, a fresh machine fails with `ModuleNotFoundError: No module
 
 ### 9. Pin dependency versions
 
-Generate `requirements.txt` with exact versions and cryptographic hashes using `pip-compile --generate-hashes`.
+We generate `requirements.txt` with exact versions and cryptographic hashes using `pip-compile --generate-hashes`.
 
 There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
-The first is a declaration — it says what you need.
+The first is a declaration — it says what we need.
 The second is a distribution-ready specification — it says exactly what bytes to install.
-Hash pinning means that even if a package is re-uploaded with the same version number, the install will reject it rather than silently using different code.
+Hash pinning means that even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
 This is where Portability meets Tracking: the environment specification itself is content-addressed.
 
 **Advances**: P (reproducible environment), T (pinned versions are content-addressed)
@@ -167,7 +161,7 @@ This is where Portability meets Tracking: the environment specification itself i
 
 ### 10. Record provenance with datalad run
 
-Wrap the fetch and analysis commands with `datalad run`, which records the exact command, inputs, and outputs as machine-readable metadata in each commit.
+We wrap the fetch and analysis commands with `datalad run`, which records the exact command, inputs, and outputs as machine-readable metadata in each commit.
 
 A regular git commit says "these files changed."
 A `datalad run` commit says "these files changed *because this command was run with these inputs and produced these outputs*."
@@ -182,14 +176,14 @@ And because the record is executable, anyone can replay it with `datalad rerun`.
 
 ### 11. Push to GitHub
 
-`git push` to a public repository.
+We push to a public repository.
 Now anyone can `git clone`, `pip install -r requirements.txt`, `make`, and reproduce the result.
 
-Until this step, the research object was self-contained and reproducible — but only on your machine.
+Until this step the research object was self-contained and reproducible — but only on our machine.
 Publishing crosses the Distributability threshold (D.1): all components become persistently retrievable by others.
 
-Note that GitHub is hosting, not archival.
-For long-term persistence, the next step would be depositing on Zenodo or Software Heritage (see "Where to go from here").
+GitHub is hosting, not archival.
+For long-term persistence the next step would be depositing on Zenodo or Software Heritage (see "Where to go from here").
 
 **Advances**: D (persistently retrievable by others)
 
@@ -197,14 +191,14 @@ For long-term persistence, the next step would be depositing on Zenodo or Softwa
 
 ### 12. Reproduce from scratch
 
-Write a script that clones the repository into a fresh temp directory, installs dependencies, runs the pipeline, and runs the tests.
-If it passes, the research object doesn't depend on anything from your machine — no accumulated state, no forgotten steps.
+We write a script that clones the repository into a fresh temp directory, installs dependencies, runs the pipeline, and runs the tests.
+If it passes, the research object doesn't depend on anything from our machine — no accumulated state, no forgotten steps.
 The temp directory is thrown away afterward.
 
-This is the ultimate integration test for a research object.
+This is the integration test for a research object.
 Ephemeral reproduction exercises almost every STAMPED property at once: the project must be self-contained (S), the pipeline must actually run (A), it must work in a fresh environment (P), and there's no prior state to lean on (E).
-If `reproduce_from_scratch.sh` passes, you have strong evidence that your research object is solid.
-If it fails, the error message tells you which property broke.
+If `reproduce_from_scratch.sh` passes, we have strong evidence that the research object is solid.
+If it fails, the error tells us which property broke.
 
 This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-reproducer" >}}) pattern applied to our own project.
 
@@ -227,11 +221,11 @@ This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-repro
 ## Where to go from here
 
 Each STAMPED property is a spectrum.
-We've built something solid, but there are natural next steps depending on what your project needs.
+We've built something solid, but there are natural next steps depending on what the project needs.
 
 **Containers for portability and ephemerality**:
 A Dockerfile (pinned by image digest) freezes the OS and Python version.
-Running the pipeline inside a disposable container validates that the specifications are complete — if it works in a fresh container, it's not relying on anything from your machine.
+Running the pipeline inside a disposable container validates that the specifications are complete — if it works in a fresh container, it's not relying on anything from our machine.
 See [Container venv overlay for Python development]({{< ref "examples/container-venv-overlay-development" >}}) for a detailed treatment of this pattern.
 
 **CI for ephemeral validation**:

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -33,11 +33,9 @@ The result is a CSV of stellar distances in parsecs — verified against Gaia's 
 
 The analysis is deliberately simple so the focus stays on *how* we organize, track, and share the work.
 
-**Repository**: [TODO: link to GitHub repo]
-
 ## Steps
 
-### 1. Proof of concept
+### 1. Start a project
 
 We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
 
@@ -50,14 +48,29 @@ QUERY = (
     "ORDER BY parallax DESC"
 )
 
-# ... fetch from Gaia TAP API ...
+with urllib.request.urlopen(f"{GAIA_TAP_URL}?{params}") as resp:
+    raw = resp.read().decode()
 
-for star in reader:
+for star in csv.DictReader(io.StringIO(raw)):
     distance_pc = 1000.0 / float(star["parallax"])
 ```
 
-Run it, get a `distances.csv` with 100 rows, done.
+Run it, get a `distances.csv` with 100 rows.
 Proxima Centauri shows up at ~1.30 parsecs — looks right.
+
+We put it in a directory and run `git init`.
+Two things happen at once: we draw a boundary around the project (Self-containment), and we start recording its history (Tracking).
+The boundary is the "don't look up" rule (S.1): everything needed for this work lives inside one root, and nothing outside should be implicitly required.
+Git gives us content-addressed version control — each commit hash is a cryptographic fingerprint of the entire project state, not an ambiguous label like "version 1.0."
+
+From now on, every change is recorded and reversible.
+That makes all subsequent steps low-risk.
+
+```
+stellar-distance/
+├── compute_everything.py
+└── distances.csv
+```
 
 This is where most analyses live forever — and that's fine for exploration.
 But what happens when we come back in six months and can't remember which query parameters we used?
@@ -66,24 +79,9 @@ When a reviewer asks us to recompute with updated data?
 
 Each step that follows addresses one of these failure modes.
 
-**Commit**: [TODO]
-
-### 2. Gather and start tracking
-
-We put everything in a single project directory and run `git init`.
-
-Two things happen at once here: we draw a boundary around the project (Self-containment), and we start recording its history (Tracking).
-The boundary is the "don't look up" rule (S.1): everything needed for this work lives inside one root, and nothing outside should be implicitly required.
-Git gives us content-addressed version control — each commit hash is a cryptographic fingerprint of the entire project state, not an ambiguous label like "version 1.0."
-
-From now on, every change is recorded and reversible.
-That makes all subsequent steps low-risk.
-
 **Advances**: S (everything reachable from one root), T (content identification, change history)
 
-**Commit**: [TODO]
-
-### 3. Split the script and fetch data with provenance
+### 2. Split scripts and fetch data with provenance
 
 The monolithic script does two things — fetch and compute — and there's no way to re-run one without the other.
 We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `compute_distances.py` to calculate distances from that data.
@@ -104,7 +102,9 @@ def fetch(output_path):
 ```python
 # compute_distances.py
 def main(input_path, output_path):
-    # ... read input CSV ...
+    with open(input_path) as f:
+        stars = list(csv.DictReader(f))
+    # ...
     for star in stars:
         distance_pc = 1000.0 / float(star["parallax"])
     # ... write output CSV ...
@@ -129,19 +129,29 @@ The API is still the authoritative source, but we're no longer silently dependen
 
 `datalad run` works on plain git repositories — no special initialization required.
 
+```
+stellar-distance/
+├── compute_distances.py
+├── fetch_data.py
+├── gaia_nearby.csv
+└── distances.csv
+```
+
 **Advances**: T (programmatic provenance), S (versioned local copy of external data), A (provenance is re-executable)
 
-**Commits**: [TODO] (split scripts), [TODO] (datalad run fetch)
-
-### 4. Organize into directories
+### 3. Organize into directories
 
 We create `code/`, `raw/`, and `output/` directories, and move each file to where it belongs:
 
 ```
-code/fetch_data.py
-code/compute_distances.py
-raw/gaia_nearby.csv
-output/distances.csv
+stellar-distance/
+├── code/
+│   ├── fetch_data.py
+│   └── compute_distances.py
+├── raw/
+│   └── gaia_nearby.csv
+└── output/
+    └── distances.csv
 ```
 
 Code is what we write, raw is what we fetch, output is what we compute.
@@ -152,11 +162,9 @@ This is Modularity at its simplest — not separate repositories, just separate 
 
 **Advances**: M (logical separation of concerns), S (clearer boundary)
 
-**Commit**: [TODO]
+### 4. Record the analysis with provenance
 
-### 5. Record the analysis with provenance
-
-Just as we used `datalad run` for the fetch in step 3, we now use it for the analysis:
+Just as we used `datalad run` for the fetch in step 2, we now use it for the analysis:
 
 ```sh
 datalad run \
@@ -173,21 +181,33 @@ Anyone can inspect the commit messages to see exactly how each file was produced
 
 **Advances**: T (full pipeline provenance), A (analysis is re-executable via `datalad rerun`)
 
-**Commit**: [TODO]
+### 5. Write a README
 
-### 6. Write a README
+We add a README explaining what this project does, what the inputs and outputs are, and how to run it:
 
-We add a README explaining what this project does, what the inputs and outputs are, and how to run it.
+```markdown
+# Stellar Distance from Gaia Parallax
 
-Without one, the project is only usable by the person who wrote it — and only while they remember how.
+Compute distances to nearby stars using parallax measurements from the
+Gaia DR3 catalog.
+
+**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
+**Output**: Source IDs and computed distances (parsecs).
+**Method**: `distance_pc = 1000 / parallax_mas`
+
+## Reproduce
+
+    python3 code/fetch_data.py raw/gaia_nearby.csv
+    python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
+```
+
+Without a README, the project is only usable by the person who wrote it — and only while they remember how.
 A README makes it usable by anyone who can read.
 This is the minimum viable Actionability (A.1): sufficient instructions to reproduce all results.
 
 **Advances**: A (someone can now follow instructions to reproduce), S (project is self-describing)
 
-**Commit**: [TODO]
-
-### 7. Write a Makefile
+### 6. Write a Makefile
 
 We encode the pipeline as `make` targets with their dependencies:
 
@@ -206,11 +226,11 @@ The Makefile *does* it.
 This is the jump from documented to executable — the Actionability spectrum in action (A.2).
 Make also encodes dependencies: it knows what to re-run when an input changes, which is itself a lightweight form of provenance.
 
+Now `make` is the single command to reproduce everything. We update the README accordingly.
+
 **Advances**: A (executable specification — not just documentation but a runnable recipe)
 
-**Commit**: [TODO]
-
-### 8. Add a test
+### 7. Add a test
 
 We write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
 `make test` runs it.
@@ -229,13 +249,46 @@ A test makes the claim falsifiable — anyone can run `make test` and see for th
 Only 48 of our 100 stars have GSP-Phot distances because Gaia's sophisticated pipeline doesn't produce estimates for every star.
 Our simple one-line formula actually covers more stars than the pipeline does.
 
+```
+stellar-distance/
+├── code/
+│   ├── fetch_data.py
+│   └── compute_distances.py
+├── raw/
+│   └── gaia_nearby.csv
+├── output/
+│   └── distances.csv
+├── test/
+│   ├── fetch_reference_distances.sh
+│   └── verify_distances.py
+├── Makefile
+└── README.md
+```
+
 **Advances**: A (verifiable results, not just "trust me")
 
-**Commit**: [TODO]
+### 8. Declare and pin dependencies
 
-### 9. Declare and pin dependencies
+Until now the scripts used only Python's standard library (urllib, csv).
+We rewrite the fetch script to use `requests` — cleaner API, better error handling — which introduces an external dependency.
 
-We add `pyproject.toml` listing the Python packages we use, then generate a hash-locked `requirements.txt`:
+```python
+# fetch_data.py (rewritten)
+import requests
+
+def fetch(output_path, limit=100, min_parallax=10, max_error_ratio=0.1):
+    resp = requests.get(GAIA_TAP_URL, params={
+        "REQUEST": "doQuery", "LANG": "ADQL", "FORMAT": "csv",
+        "QUERY": query,
+    })
+    resp.raise_for_status()
+    with open(output_path, "w") as f:
+        f.write(resp.text)
+```
+
+Without declaring the dependency, a fresh machine fails with `ModuleNotFoundError` — a Portability failure that only surfaces when someone else tries to run the code.
+
+We add `pyproject.toml` to make the assumption explicit, then generate a hash-locked `requirements.txt`:
 
 ```toml
 # pyproject.toml
@@ -250,12 +303,7 @@ dependencies = ["requests"]
 pip-compile --generate-hashes -o requirements.txt pyproject.toml
 ```
 
-Until now the scripts used only Python's standard library.
-When we rewrote the fetch script to use `requests` (cleaner API, better error handling), we introduced an external dependency.
-Without declaring it, a fresh machine fails with `ModuleNotFoundError` — a Portability failure that only surfaces when someone else tries to run the code.
-
-`pyproject.toml` makes the assumption explicit.
-`requirements.txt` with hashes goes further: there's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
+There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
 The first is a declaration — it says what we need.
 The second is a distribution-ready specification — it says exactly what bytes to install.
 Hash pinning means even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
@@ -263,11 +311,9 @@ This is where Portability meets Tracking: the environment specification itself i
 
 **Advances**: P (host assumptions documented, reproducible environment), T (pinned versions are content-addressed)
 
-**Commits**: [TODO] (pyproject.toml), [TODO] (requirements.txt)
+### 9. Reproduce from scratch
 
-### 10. Reproduce from scratch
-
-We write a script that clones the repository into a fresh temp directory, installs dependencies, runs the pipeline, and runs the tests:
+We write a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
 
 ```sh
 #!/bin/sh
@@ -300,9 +346,7 @@ This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-repro
 
 **Advances**: E (results produced without prior state), A (reproduction is a single command), S (validates that nothing outside the boundary is needed)
 
-**Commit**: [TODO]
-
-### 11. Push to GitHub
+### 10. Push to GitHub
 
 We push to a public repository.
 Now anyone can `git clone`, `pip install -r requirements.txt`, `make`, and reproduce the result.
@@ -313,9 +357,26 @@ Publishing crosses the Distributability threshold (D.1): all components become p
 GitHub is hosting, not archival.
 For long-term persistence the next step would be depositing on Zenodo or Software Heritage (see "Where to go from here").
 
-**Advances**: D (persistently retrievable by others)
+```
+stellar-distance/
+├── code/
+│   ├── fetch_data.py
+│   └── compute_distances.py
+├── raw/
+│   └── gaia_nearby.csv
+├── output/
+│   └── distances.csv
+├── test/
+│   ├── fetch_reference_distances.sh
+│   ├── verify_distances.py
+│   └── reproduce_from_scratch.sh
+├── Makefile
+├── README.md
+├── pyproject.toml
+└── requirements.txt
+```
 
-**Commit**: [TODO]
+**Advances**: D (persistently retrievable by others)
 
 ## STAMPED scorecard
 
@@ -384,7 +445,7 @@ See [Container venv overlay for Python development]({{< ref "examples/container-
 ### CI for ephemeral validation
 
 A GitHub Actions workflow that clones, installs, and runs `make test` on every push.
-This catches environment drift automatically — the ephemeral reproduction test from step 10, run by someone else's machine on every change.
+This catches environment drift automatically — the ephemeral reproduction test from step 9, run by someone else's machine on every change.
 
 ### Archival distribution
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -16,15 +16,22 @@ params:
 
 ## What we're building
 
-<!-- TODO: wordsmith — enthusiastic intro framing the walkthrough as building a research object, not just running an analysis. Tone: practical, motivating, "you'll be surprised how far simple steps get you." -->
+Most research code starts the same way: a script that works, on your machine, right now.
+That's not a problem — it's a starting point.
 
-We compute the distance to 100 nearby stars using parallax measurements from the European Space Agency's [Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
+In this walkthrough we take a real analysis — computing distances to nearby stars from European Space Agency data — and turn it into something anyone can verify, reproduce, and build on.
+No new frameworks to learn.
+No heavyweight infrastructure.
+Just a series of small, practical steps, each one solving a concrete problem you've probably already run into: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
+
+Along the way, we'll point out which STAMPED properties each step improves.
+By the end, you'll have a research object that passes a from-scratch reproduction test in a throwaway directory — and you'll see that most of the steps are things you might already be doing, just named and organized.
+
+**The science**: we compute the distance to 100 nearby stars using parallax measurements from the [Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
 The math is one line: `distance_pc = 1000 / parallax_mas`.
 The result is a CSV of stellar distances in parsecs — verified against Gaia's own pipeline estimates to within 0.3%.
 
 The analysis is deliberately simple so the focus stays on *how* we organize, track, and share the work.
-Each step is a concrete action.
-We note which STAMPED properties each step improves.
 
 **Repository**: [TODO: link to GitHub repo]
 
@@ -32,13 +39,17 @@ We note which STAMPED properties each step improves.
 
 ### 1. Proof of concept
 
-Write a Python script that queries the Gaia TAP API, fetches parallax for 100 nearby stars, computes `distance_pc = 1000 / parallax`, and writes a CSV.
-Run it. Get a result. Done.
+Write a single Python script that queries the Gaia TAP API, fetches parallax for 100 nearby stars, computes `distance_pc = 1000 / parallax`, and writes a CSV.
+Run it.
+Get a result.
+Done.
 
-This is where most analyses live forever.
-Not STAMPED at all — but it works, and that matters.
+This is where most analyses live forever — and that's fine for exploration.
+But what happens when you come back in six months and can't remember which query parameters you used?
+When a collaborator asks "how do I run this?" and the answer is "well, first you need to install..."?
+When a reviewer asks you to recompute with updated data?
 
-<!-- TODO: expand — frame the tension: the script works but is fragile. What happens when you come back in six months? When a collaborator tries to run it? When a reviewer asks how you got the numbers? Each subsequent step addresses one of these failure modes. -->
+Each step that follows addresses one of these failure modes.
 
 *We committed this so you can see it, but in real life this might just be a loose file on your desktop.*
 
@@ -48,16 +59,24 @@ Not STAMPED at all — but it works, and that matters.
 
 Put all files in a single project directory.
 
-<!-- TODO: explain the "don't look up" rule from Self-containment (S.1). Right now the script and output are loose — a collaborator would need to know which files go together. Gathering them establishes a boundary. -->
+This sounds obvious, but it's the foundation everything else builds on.
+Right now the script and its output are loose files — a collaborator would need to know which ones go together.
+A project directory draws a boundary: everything inside is part of this work, and nothing outside should be needed.
+STAMPED calls this the "don't look up" rule (S.1): a research object must never rely on implicit external state.
 
 **Advances**: S (everything reachable from one root)
 
 ### 3. Organize into directories
 
 Separate `code/`, `raw/`, `output/`.
-Code is what you write, raw is what you fetch, output is what you compute.
+Code is what you write.
+Raw is what you fetch.
+Output is what you compute.
 
-<!-- TODO: explain why separation matters — it tells you the role of each file at a glance. When something breaks, you know where to look. This is Modularity at its simplest: not separate repos, just separate directories with clear roles. Also: splitting the monolithic script into fetch + compute makes each piece independently testable and replaceable. -->
+This tells you the role of each file at a glance.
+When something breaks, you know where to look.
+We also split the monolithic script into two: one that fetches data, one that computes distances.
+Each piece is now independently testable and replaceable — Modularity at its simplest.
 
 **Advances**: M (logical separation of concerns), S (clearer boundary)
 
@@ -67,7 +86,9 @@ Code is what you write, raw is what you fetch, output is what you compute.
 
 Explain what this project does, what the inputs and outputs are, and how to run it.
 
-<!-- TODO: frame as the minimum viable Actionability. Without a README, the project is only actionable by the person who wrote it (and only while they remember how). A README makes it actionable by anyone who can read. This is A.1: "sufficient instructions to reproduce." -->
+Without a README, the project is only usable by the person who wrote it — and only while they remember how.
+A README makes it usable by anyone who can read.
+This is the minimum viable Actionability (A.1): sufficient instructions to reproduce all results.
 
 **Advances**: A (someone can now follow instructions to reproduce), S (project is self-describing)
 
@@ -80,7 +101,8 @@ Explain what this project does, what the inputs and outputs are, and how to run 
 From now on, every change is recorded: who, when, what, and (in the commit message) why.
 You can always get back to any previous state.
 
-<!-- TODO: explain content-addressed identification (T.1) — each commit hash is a fingerprint of the entire project state. This is stronger than "version 1.0" labels because two people with the same hash provably have the same content. Also: version control is the safety net that makes all subsequent steps low-risk — you can always revert. -->
+Each commit hash is a fingerprint of the entire project state — not a label like "version 1.0" that two people could apply to different things, but a cryptographic checksum that two people with the same hash provably have the same content.
+Version control is also the safety net that makes every subsequent step low-risk: if something goes wrong, you can always revert.
 
 **Advances**: T (content identification, change history)
 
@@ -91,7 +113,10 @@ You can always get back to any previous state.
 Encode the pipeline as `make` targets: `raw/gaia_nearby.csv` depends on `code/fetch_data.py`, `output/distances.csv` depends on `raw/gaia_nearby.csv` and `code/compute_distances.py`.
 `make` runs the whole thing.
 
-<!-- TODO: frame the jump from "documented" to "executable." The README says how to run the pipeline; the Makefile actually runs it. This is the Actionability spectrum in action (A.2): moving from prose instructions to an executable specification. Also note that Make encodes dependencies — it knows what to re-run when inputs change, which is a form of provenance. -->
+The README *says* how to run the pipeline.
+The Makefile *does* it.
+This is the jump from documented to executable — the Actionability spectrum in action (A.2).
+Make also encodes dependencies: it knows what to re-run when an input changes, which is itself a lightweight form of provenance.
 
 **Advances**: A (executable specification — not just documentation but a runnable recipe)
 
@@ -103,7 +128,11 @@ Write a verification script that fetches independent reference distances from Ga
 `make test` runs it.
 48 of 100 stars have reference values; all match within 0.3%.
 
-<!-- TODO: explain why testing is Actionability, not just good practice. A research object without verification asks others to trust the results. A test makes the claim falsifiable — anyone can run `make test` and see for themselves. Also note: not all 100 stars have GSP-Phot distances (only 48 do), which actually demonstrates that our simple formula covers more stars than the sophisticated pipeline. -->
+A research object without verification asks others to trust the results.
+A test makes the claim falsifiable — anyone can run `make test` and see for themselves.
+
+An interesting detail: only 48 of our 100 stars have GSP-Phot distances, because Gaia's sophisticated pipeline doesn't produce estimates for every star.
+Our simple one-line formula actually covers more stars than the pipeline does.
 
 **Advances**: A (verifiable results, not just "trust me")
 
@@ -113,7 +142,10 @@ Write a verification script that fetches independent reference distances from Ga
 
 Add `pyproject.toml` listing the Python packages we use (`requests`).
 
-<!-- TODO: frame the problem this solves. Until now, the scripts used only stdlib (urllib). When we rewrote fetch_data.py to use `requests` (cleaner API, better error handling), we introduced an external dependency. Without declaring it, a fresh machine would fail with `ModuleNotFoundError: No module named 'requests'` — a Portability failure. pyproject.toml makes the assumption explicit (P.1, P.2). -->
+Until now, the scripts used only Python's standard library.
+When we rewrote the fetch script to use `requests` (cleaner API, better error handling), we introduced an external dependency.
+Without declaring it, a fresh machine fails with `ModuleNotFoundError: No module named 'requests'` — a Portability failure that only surfaces when someone else tries to run the code.
+`pyproject.toml` makes that assumption explicit.
 
 **Advances**: P (host assumptions are now documented, not implicit)
 
@@ -121,10 +153,13 @@ Add `pyproject.toml` listing the Python packages we use (`requests`).
 
 ### 9. Pin dependency versions
 
-Generate `requirements.txt` with exact versions.
-Better: use `pip-compile --generate-hashes` for hash-pinned versions — guarantees byte-identical packages.
+Generate `requirements.txt` with exact versions and cryptographic hashes using `pip-compile --generate-hashes`.
 
-<!-- TODO: explain the difference between "requests" (any version) and "requests==2.32.5 --hash=sha256:..." (this exact build). The former is a declaration; the latter is a distribution-ready specification. Hash pinning means even if a package is re-uploaded with the same version number, the install will fail rather than silently use different code. This is where Portability meets Tracking — the environment specification is content-addressed. -->
+There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
+The first is a declaration — it says what you need.
+The second is a distribution-ready specification — it says exactly what bytes to install.
+Hash pinning means that even if a package is re-uploaded with the same version number, the install will reject it rather than silently using different code.
+This is where Portability meets Tracking: the environment specification itself is content-addressed.
 
 **Advances**: P (reproducible environment), T (pinned versions are content-addressed)
 
@@ -133,11 +168,13 @@ Better: use `pip-compile --generate-hashes` for hash-pinned versions — guarant
 ### 10. Record provenance with datalad run
 
 Wrap the fetch and analysis commands with `datalad run`, which records the exact command, inputs, and outputs as machine-readable metadata in each commit.
-The provenance is not just inspectable — it's re-executable via `datalad rerun`.
 
-Note: `datalad run` works on plain git repositories — no DataLad dataset or git-annex required.
+A regular git commit says "these files changed."
+A `datalad run` commit says "these files changed *because this command was run with these inputs and produced these outputs*."
+The run record is JSON embedded in the commit message — machine-readable, not just human-readable.
+And because the record is executable, anyone can replay it with `datalad rerun`.
 
-<!-- TODO: explain what datalad run adds beyond "git commit." A regular commit says "these files changed." A datalad run commit says "these files changed because this command was run with these inputs and produced these outputs." The run record is JSON embedded in the commit message — machine-readable, not just human-readable. This is T.4: programmatic provenance that includes component versions. And because the record is executable, it's also A.2: an executable specification. -->
+`datalad run` works on plain git repositories — no special dataset initialization or git-annex required.
 
 **Advances**: T (programmatic provenance), A (provenance records are executable specifications)
 
@@ -148,7 +185,11 @@ Note: `datalad run` works on plain git repositories — no DataLad dataset or gi
 `git push` to a public repository.
 Now anyone can `git clone`, `pip install -r requirements.txt`, `make`, and reproduce the result.
 
-<!-- TODO: frame as the Distributability threshold — D.1 says all components must be "persistently retrievable by others." Until this step, the research object was self-contained and reproducible but only on your machine. Publishing makes it distributable. Note: GitHub is not archival — for long-term persistence, Zenodo or Software Heritage would be the next step (see "Where to go from here"). -->
+Until this step, the research object was self-contained and reproducible — but only on your machine.
+Publishing crosses the Distributability threshold (D.1): all components become persistently retrievable by others.
+
+Note that GitHub is hosting, not archival.
+For long-term persistence, the next step would be depositing on Zenodo or Software Heritage (see "Where to go from here").
 
 **Advances**: D (persistently retrievable by others)
 
@@ -160,9 +201,12 @@ Write a script that clones the repository into a fresh temp directory, installs 
 If it passes, the research object doesn't depend on anything from your machine — no accumulated state, no forgotten steps.
 The temp directory is thrown away afterward.
 
-This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-reproducer" >}}) pattern applied to our own project.
+This is the ultimate integration test for a research object.
+Ephemeral reproduction exercises almost every STAMPED property at once: the project must be self-contained (S), the pipeline must actually run (A), it must work in a fresh environment (P), and there's no prior state to lean on (E).
+If `reproduce_from_scratch.sh` passes, you have strong evidence that your research object is solid.
+If it fails, the error message tells you which property broke.
 
-<!-- TODO: explain why this is the ultimate integration test for STAMPED. Ephemeral reproduction exercises almost every property at once: S (everything needed must be inside the boundary), A (the pipeline must actually run), P (it must work in a fresh environment), E (no prior state). If reproduce_from_scratch.sh passes, you have strong evidence that your research object is STAMPED. If it fails, the error message tells you exactly which property broke. -->
+This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-reproducer" >}}) pattern applied to our own project.
 
 **Advances**: E (results produced without prior state), A (reproduction is a single command), S (validates that nothing outside the boundary is needed)
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -82,25 +82,20 @@ Each step that follows addresses one of these failure modes.
 The monolithic script does two things — fetch and compute — and there's no way to re-run one without the other.
 We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `compute_distances.py` to calculate distances from that data.
 
+<!-- TODO: link to fetch_data.py and compute_distances.py commits once repo history is restructured -->
+
 ```python
-# fetch_data.py
+# fetch_data.py (abbreviated)
 def fetch(output_path):
-    params = urllib.parse.urlencode({
-        "REQUEST": "doQuery", "LANG": "ADQL", "FORMAT": "csv",
-        "QUERY": QUERY,
-    })
-    with urllib.request.urlopen(f"{GAIA_TAP_URL}?{params}") as resp:
-        data = resp.read().decode()
+    # ... query Gaia TAP API with urllib ...
     with open(output_path, "w") as f:
         f.write(data)
 ```
 
 ```python
-# compute_distances.py
+# compute_distances.py (abbreviated)
 def main(input_path, output_path):
-    with open(input_path) as f:
-        stars = list(csv.DictReader(f))
-    # ...
+    # ... read input CSV ...
     for star in stars:
         distance_pc = 1000.0 / float(star["parallax"])
     # ... write output CSV ...
@@ -266,21 +261,18 @@ stellar-distance/
 
 ### 8. Declare and pin dependencies
 
-Until now the scripts used only Python's standard library (urllib, csv).
-We rewrite the fetch script to use `requests` — cleaner API, better error handling — which introduces an external dependency.
+Until now the scripts used only Python's standard library (urllib, csv), so there was nothing to declare.
+To demonstrate how dependencies are handled, we rewrite the fetch script to use `requests`:
+
+<!-- TODO: link to fetch_data.py rewrite commit once repo history is restructured -->
 
 ```python
-# fetch_data.py (rewritten)
+# fetch_data.py (abbreviated)
 import requests
 
-def fetch(output_path, limit=100, min_parallax=10, max_error_ratio=0.1):
-    resp = requests.get(GAIA_TAP_URL, params={
-        "REQUEST": "doQuery", "LANG": "ADQL", "FORMAT": "csv",
-        "QUERY": query,
-    })
-    resp.raise_for_status()
-    with open(output_path, "w") as f:
-        f.write(resp.text)
+def fetch(output_path, ...):
+    resp = requests.get(GAIA_TAP_URL, params={...})
+    # ... write resp.text to output_path ...
 ```
 
 Without declaring the dependency, a fresh machine fails with `ModuleNotFoundError` — a Portability failure that only surfaces when someone else tries to run the code.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -128,6 +128,7 @@ Once we've fetched the data with `datalad run`, we have our own versioned copy.
 The API is still the authoritative source, but we're no longer silently dependent on it — the provenance record documents where the data came from, and the committed CSV means the analysis can proceed offline.
 
 `datalad run` works on plain git repositories — no special initialization required.
+It creates a normal git commit whose message includes a machine-readable run record (the command, inputs, and outputs), so `git log` still tells the whole story.
 
 ```
 stellar-distance/

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -837,7 +837,7 @@ DataLad subdatasets take modularity further.
 The raw data could live in its own independently versioned dataset:
 
 ```sh
-datalad clone <data-url> raw/
+datalad clone -d . DATA_URL raw/
 ```
 
 A colleague running a different analysis on the same stars would `datalad install` the data module rather than re-fetching from the API.
@@ -845,6 +845,7 @@ The parent dataset records which exact version of each subdataset it depends on,
 
 ### Containers for portability and ephemerality
 
+Our `requirements.txt` pins Python packages, but what about the Python version itself? Or the OS libraries it links against?
 A Dockerfile (pinned by image digest) freezes the OS and Python version.
 Running the pipeline inside a disposable container validates that the specifications are complete.
 If it works in a fresh container, it's not relying on anything from our machine.
@@ -852,11 +853,54 @@ See [Container venv overlay for Python development]({{< ref "examples/container-
 
 ### CI for ephemeral validation
 
-A GitHub Actions workflow that clones, installs, and runs `make test` on every push.
-This catches environment drift automatically: the same ephemeral test from step 9, run by someone else's machine on every change.
+Step 9's reproduction test proves the pipeline works from scratch, but only when we remember to run it.
+A GitHub Actions workflow that clones, installs, and runs `make test` on every push catches environment drift automatically: the same ephemeral test from step 9, run by someone else's machine on every change.
 
 ### Archival distribution
 
-Deposit the repository on [Zenodo](https://zenodo.org/) for a DOI.
+GitHub is where we collaborate, but repositories can be deleted, reorganized, or made private.
+For long-term citability, deposit the repository on [Zenodo](https://zenodo.org/) for a DOI.
 Push the container image to a registry.
 Mirror data to multiple remotes so no single point of failure breaks reproducibility.
+
+{{< mermaid >}}
+graph TD
+    subgraph external resources
+        direction LR
+        TAP[("Gaia TAP server<br/>(source data)")]
+        PyPI[("PyPI<br/>(dependencies)")]
+    end
+    subgraph local machine
+        direction LR
+        P["research project<br/>(origin of work)"]
+        E["ephemeral clone<br/>(verify reproducibility)"]
+        style E stroke-dasharray: 5 5
+        E2["ephemeral clone<br/>(verify reproducibility)"]
+        style E2 stroke-dasharray: 5 5
+        P -- "code/reproduce_from_scratch.sh $PWD" --> E
+    end
+    subgraph sharing and archival
+        direction LR
+        G["GitHub<br/>(collaborate & share)"]
+        Z["Zenodo<br/>(long-term archive)"]
+        D["DOI registrar"]
+        G -- "archive a copy" --> Z
+        Z -. "points" .-> G
+        Z -. "mints" .-> D
+    end
+    TAP -- "datalad run<br/>(fetch parallax data)" --> P
+    PyPI -- "pip install -r<br/>requirements.txt" --> E
+    PyPI -- "pip install -r<br/>requirements.txt" --> E2
+    P -- "git push" --> G
+    D -. "resolves to" .-> Z
+    G -- "git clone;<br/>make" --> E2
+{{< /mermaid >}}
+
+## Conclusion
+
+We started with a script that worked on one machine and ended with a research object that anyone can clone, run, verify, and cite.
+None of the individual steps were large: split some files, add a Makefile, write a test, pin dependencies.
+Each one addressed a specific failure mode: "I can't remember how to run this," "it doesn't work on your machine," "how do I know the numbers are right?"
+
+The STAMPED properties gave us a vocabulary for those failure modes and a way to check our progress.
+Not every project needs every step, but knowing the spectrum makes it easier to decide what's worth doing next.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -112,20 +112,12 @@ git tag stellar-step-1
 
 We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
 
-The [full script](https://github.com/asmacdo/STAMPED-stellar-distances/blob/0d95ecc/compute_everything.py) fetches data and computes distances in one pass:
+{{< snippet id="compute-everything" lang="python" lines="1-2,9-15,31-32" >}}
 
-```python
-# compute_everything.py (abbreviated)
-QUERY = "SELECT TOP 100 source_id, parallax FROM gaiadr3.gaia_source ..."
+The above is abbreviated. To follow along, see the [full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-1).
 
-# ... fetch from Gaia TAP API ...
-
-for star in csv.DictReader(io.StringIO(raw)):
-    distance_pc = 1000.0 / float(star["parallax"])
-```
-
-Run it, get a `distances.csv` with 100 rows.
-Proxima Centauri shows up at ~1.30 parsecs — looks right.
+When we run `python3 compute_everything.py`, we get a `distances.csv` with 100 rows.
+Proxima Centauri shows up at ~1.30 parsecs. Looks right!
 
 We put the script and its output in a directory and run `git init`.
 Two things happen at once: we draw a boundary around the project (Self-containment), and we start recording its history (Tracking).
@@ -141,7 +133,7 @@ stellar-distance/
 └── distances.csv
 ```
 
-This is where most analyses live forever — and that's fine for exploration.
+This is where most analyses live forever, and that's fine for exploration.
 But what happens when we come back in six months and can't remember which query parameters we used?
 When a collaborator asks "how do I run this?"
 When a reviewer asks us to recompute with updated data?

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -25,12 +25,13 @@ params:
 set -eux
 PS4='> '
 
-# Build environment — tools needed by later steps
-python3 -m venv "${TMPDIR:-/tmp}/.build-env"
-. "${TMPDIR:-/tmp}/.build-env/bin/activate"
-pip install pip-tools datalad requests
-
+# Random temp dir for containment and security (no deterministic paths under /tmp)
 cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
+
+# Build venv — tools needed by later steps
+python3 -m venv .venv
+. .venv/bin/activate
+pip install pip-tools datalad requests
 ```
 
 ## What we're building

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -39,17 +39,13 @@ The analysis is deliberately simple so the focus stays on *how* we organize, tra
 
 We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
 
+The [full script](https://github.com/asmacdo/STAMPED-stellar-distances/blob/0d95ecc/compute_everything.py) fetches data and computes distances in one pass:
+
 ```python
 # compute_everything.py (abbreviated)
-QUERY = (
-    "SELECT TOP 100 source_id, parallax "
-    "FROM gaiadr3.gaia_source "
-    "WHERE parallax > 10 AND parallax_error/parallax < 0.1 "
-    "ORDER BY parallax DESC"
-)
+QUERY = "SELECT TOP 100 source_id, parallax FROM gaiadr3.gaia_source ..."
 
-with urllib.request.urlopen(f"{GAIA_TAP_URL}?{params}") as resp:
-    raw = resp.read().decode()
+# ... fetch from Gaia TAP API ...
 
 for star in csv.DictReader(io.StringIO(raw)):
     distance_pc = 1000.0 / float(star["parallax"])
@@ -58,10 +54,10 @@ for star in csv.DictReader(io.StringIO(raw)):
 Run it, get a `distances.csv` with 100 rows.
 Proxima Centauri shows up at ~1.30 parsecs — looks right.
 
-We put it in a directory and run `git init`.
+We put the script and its output in a directory and run `git init`.
 Two things happen at once: we draw a boundary around the project (Self-containment), and we start recording its history (Tracking).
-The boundary is the "don't look up" rule (S.1): everything needed for this work lives inside one root, and nothing outside should be implicitly required.
-Git gives us content-addressed version control — each commit hash is a cryptographic fingerprint of the entire project state, not an ambiguous label like "version 1.0."
+The project boundary is one way to follow the don't look up rule (S.1): everything needed for this work lives inside one root, and nothing outside should be implicitly required.
+Git gives us content-addressed version control, so we can track changes over time and identify each project state by its commit.
 
 From now on, every change is recorded and reversible.
 That makes all subsequent steps low-risk.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -267,9 +267,9 @@ Now we do something important: instead of just running `fetch_data.py`, we wrap 
 ```sh
 # pragma: testrun full-build
 datalad run \
-  -m "Fetch 100 nearest stars from Gaia DR3" \
-  -o "gaia_nearby.csv" \
-  "python3 fetch_data.py gaia_nearby.csv"
+  --message "Fetch 100 nearest stars from Gaia DR3" \
+  --output gaia_nearby.csv \
+  python3 fetch_data.py gaia_nearby.csv
 ```
 
 ```sh
@@ -353,11 +353,11 @@ Just as we used `datalad run` for the fetch in step 2, we now use it for the ana
 ```sh
 # pragma: testrun full-build
 datalad run \
-  -m "Compute distances for 100 nearest stars" \
-  -i "raw/gaia_nearby.csv" \
-  -i "code/compute_distances.py" \
-  -o "output/distances.csv" \
-  "python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv"
+  --message "Compute distances for 100 nearest stars" \
+  --input raw/gaia_nearby.csv \
+  --input code/compute_distances.py \
+  --output output/distances.csv \
+  python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
 ```
 
 ```sh
@@ -366,7 +366,7 @@ datalad run \
 git tag stellar-step-4
 ```
 
-The `-i` flags declare inputs and `-o` declares outputs.
+The `--input` flags declare inputs and `--output` declares outputs.
 Now the full pipeline — from raw data to final results — has machine-readable provenance.
 Anyone can inspect the commit messages to see exactly how each file was produced.
 
@@ -870,9 +870,9 @@ We update the query parameters in `fetch_data.py`, then re-run just the fetch:
 
 ```sh
 datalad run \
-  -m "Fetch 200 nearest stars from Gaia DR3" \
-  -o "raw/gaia_nearby.csv" \
-  "python3 code/fetch_data.py raw/gaia_nearby.csv"
+  --message "Fetch 200 nearest stars from Gaia DR3" \
+  --output raw/gaia_nearby.csv \
+  python3 code/fetch_data.py raw/gaia_nearby.csv
 ```
 
 The new data is committed with a fresh provenance record.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -14,6 +14,19 @@ params:
   verified: true
 ---
 
+```sh
+#!/bin/sh
+# pragma: testrun full-build
+# pragma: render hidden
+# pragma: requires sh git python3 curl make pip-compile datalad
+# pragma: timeout 600
+# pragma: materialize stellar-distance
+
+set -eux
+PS4='> '
+cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
+```
+
 ## What we're building
 
 Most research code starts the same way: a script that works, on your machine, right now.
@@ -36,6 +49,57 @@ The analysis is deliberately simple so the focus stays on *how* we organize, tra
 ## Steps
 
 ### 1. Start a project
+
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+git init stellar-distance
+cd stellar-distance
+git config user.email "demo@example.com"
+git config user.name "Demo User"
+
+cat > compute_everything.py <<'PYEOF'
+#!/usr/bin/env python3
+"""Quick proof of concept: fetch Gaia parallax data and compute distances."""
+
+import csv
+import io
+import urllib.request
+import urllib.parse
+
+GAIA_TAP_URL = "https://gea.esac.esa.int/tap-server/tap/sync"
+QUERY = (
+    "SELECT TOP 100 source_id, parallax "
+    "FROM gaiadr3.gaia_source "
+    "WHERE parallax > 10 AND parallax_error/parallax < 0.1 "
+    "ORDER BY parallax DESC"
+)
+
+params = urllib.parse.urlencode({
+    "REQUEST": "doQuery",
+    "LANG": "ADQL",
+    "FORMAT": "csv",
+    "QUERY": QUERY,
+})
+
+with urllib.request.urlopen(f"{GAIA_TAP_URL}?{params}") as resp:
+    raw = resp.read().decode()
+
+reader = csv.DictReader(io.StringIO(raw))
+with open("distances.csv", "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=["source_id", "distance_pc"])
+    writer.writeheader()
+    for star in reader:
+        distance_pc = 1000.0 / float(star["parallax"])
+        writer.writerow({"source_id": star["source_id"], "distance_pc": f"{distance_pc:.4f}"})
+
+print("Done — wrote distances.csv")
+PYEOF
+
+python3 compute_everything.py
+git add compute_everything.py distances.csv
+git commit -m "Initial analysis: compute stellar distances"
+```
 
 We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
 
@@ -79,10 +143,94 @@ Each step that follows addresses one of these failure modes.
 
 ### 2. Split scripts and fetch data with provenance
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+cat > fetch_data.py <<'PYEOF'
+#!/usr/bin/env python3
+"""Fetch nearby star parallax data from Gaia DR3 via TAP query."""
+
+import sys
+import urllib.parse
+import urllib.request
+
+GAIA_TAP_URL = "https://gea.esac.esa.int/tap-server/tap/sync"
+
+QUERY = """\
+SELECT TOP {limit}
+    source_id, parallax
+FROM gaiadr3.gaia_source
+WHERE parallax > {min_parallax}
+    AND parallax_error / parallax < {max_error_ratio}
+ORDER BY parallax DESC
+"""
+
+
+def fetch(output_path, limit=100, min_parallax=10, max_error_ratio=0.1):
+    query = QUERY.format(
+        limit=limit,
+        min_parallax=min_parallax,
+        max_error_ratio=max_error_ratio,
+    )
+    params = urllib.parse.urlencode({
+        "REQUEST": "doQuery",
+        "LANG": "ADQL",
+        "FORMAT": "csv",
+        "QUERY": query,
+    })
+    with urllib.request.urlopen(f"{GAIA_TAP_URL}?{params}") as resp:
+        data = resp.read().decode()
+
+    with open(output_path, "w") as f:
+        f.write(data)
+
+    n_stars = data.count("\n") - 1
+    print(f"Fetched {n_stars} stars -> {output_path}")
+
+
+if __name__ == "__main__":
+    output = sys.argv[1] if len(sys.argv) > 1 else "gaia_nearby.csv"
+    fetch(output)
+PYEOF
+
+cat > compute_distances.py <<'PYEOF'
+#!/usr/bin/env python3
+"""Compute stellar distances from Gaia parallax measurements."""
+
+import csv
+import sys
+
+
+def main(input_path, output_path):
+    with open(input_path) as f:
+        reader = csv.DictReader(f)
+        stars = list(reader)
+
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["source_id", "distance_pc"])
+        writer.writeheader()
+        for star in stars:
+            distance_pc = 1000.0 / float(star["parallax"])
+            writer.writerow({
+                "source_id": star["source_id"],
+                "distance_pc": f"{distance_pc:.4f}",
+            })
+
+    print(f"Computed distances for {len(stars)} stars -> {output_path}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])
+PYEOF
+
+git rm compute_everything.py
+git rm distances.csv
+git add fetch_data.py compute_distances.py
+git commit -m "Split into fetch and compute scripts"
+```
+
 The monolithic script does two things — fetch and compute — and there's no way to re-run one without the other.
 We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `compute_distances.py` to calculate distances from that data.
-
-<!-- TODO: link to fetch_data.py and compute_distances.py commits once repo history is restructured -->
 
 ```python
 # fetch_data.py (abbreviated)
@@ -104,6 +252,7 @@ def main(input_path, output_path):
 Now we do something important: instead of just running `fetch_data.py`, we wrap it with `datalad run`:
 
 ```sh
+# pragma: testrun full-build
 datalad run \
   -m "Fetch 100 nearest stars from Gaia DR3" \
   -o "gaia_nearby.csv" \
@@ -133,6 +282,21 @@ stellar-distance/
 
 ### 3. Organize into directories
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+python3 compute_distances.py gaia_nearby.csv distances.csv
+git add distances.csv
+git commit -m "Compute distances from fetched data"
+
+mkdir -p code raw output
+git mv fetch_data.py code/
+git mv compute_distances.py code/
+git mv gaia_nearby.csv raw/
+git mv distances.csv output/
+git commit -m "Organize into code/, raw/, output/"
+```
+
 We create `code/`, `raw/`, and `output/` directories, and move each file to where it belongs:
 
 ```
@@ -156,9 +320,18 @@ This is Modularity at its simplest — not separate repositories, just separate 
 
 ### 4. Record the analysis with provenance
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+git rm output/distances.csv
+git commit -m "Remove output to re-compute with provenance"
+mkdir -p output
+```
+
 Just as we used `datalad run` for the fetch in step 2, we now use it for the analysis:
 
 ```sh
+# pragma: testrun full-build
 datalad run \
   -m "Compute distances for 100 nearest stars" \
   -i "raw/gaia_nearby.csv" \
@@ -174,6 +347,29 @@ Anyone can inspect the commit messages to see exactly how each file was produced
 **Advances**: T (full pipeline provenance), A (analysis is re-executable via `datalad rerun`)
 
 ### 5. Write a README
+
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+cat > README.md <<'README'
+# Stellar Distance from Gaia Parallax
+
+Compute distances to nearby stars using parallax measurements from the
+[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
+
+**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
+**Output**: Source IDs and computed distances (parsecs).
+**Method**: `distance_pc = 1000 / parallax_mas`
+
+## Reproduce
+
+    python3 code/fetch_data.py raw/gaia_nearby.csv
+    python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
+README
+
+git add README.md
+git commit -m "Add README with reproduction instructions"
+```
 
 We add a README explaining what this project does, what the inputs and outputs are, and how to run it:
 
@@ -201,6 +397,30 @@ This is the minimum viable Actionability (A.1): sufficient instructions to repro
 
 ### 6. Write a Makefile
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+printf '.POSIX:\n\nall: output/distances.csv\n\nraw/gaia_nearby.csv:\n\tpython3 code/fetch_data.py raw/gaia_nearby.csv\n\noutput/distances.csv: raw/gaia_nearby.csv code/compute_distances.py\n\tpython3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv\n\nclean:\n\trm -f output/distances.csv\n\n.PHONY: all clean\n' > Makefile
+
+cat > README.md <<'README'
+# Stellar Distance from Gaia Parallax
+
+Compute distances to nearby stars using parallax measurements from the
+[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
+
+**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
+**Output**: Source IDs and computed distances (parsecs).
+**Method**: `distance_pc = 1000 / parallax_mas`
+
+## Reproduce
+
+    make
+README
+
+git add Makefile README.md
+git commit -m "Add Makefile encoding the full pipeline"
+```
+
 We encode the pipeline as `make` targets with their dependencies:
 
 ```makefile
@@ -223,6 +443,112 @@ Now `make` is the single command to reproduce everything. We update the README a
 **Advances**: A (executable specification — not just documentation but a runnable recipe)
 
 ### 7. Add a test
+
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+mkdir -p test
+
+cat > test/fetch_reference_distances.sh <<'TESTSH'
+#!/bin/sh
+# Fetch GSP-Phot reference distances for the exact stars we computed
+set -eu
+
+ids=$(tail -n +2 output/distances.csv | cut -d, -f1 | paste -sd,)
+
+curl -s -o test/reference_distances.csv \
+  --data-urlencode "REQUEST=doQuery" \
+  --data-urlencode "LANG=ADQL" \
+  --data-urlencode "FORMAT=csv" \
+  --data-urlencode "QUERY=SELECT source_id, distance_gspphot FROM gaiadr3.gaia_source WHERE source_id IN ($ids) AND distance_gspphot IS NOT NULL" \
+  "https://gea.esac.esa.int/tap-server/tap/sync"
+
+echo "Fetched $(tail -n +2 test/reference_distances.csv | wc -l) reference distances"
+TESTSH
+chmod +x test/fetch_reference_distances.sh
+
+cat > test/verify_distances.py <<'PYEOF'
+#!/usr/bin/env python3
+"""Compare our computed distances against Gaia GSP-Phot reference distances."""
+
+import csv
+import sys
+
+
+def main():
+    computed = {}
+    with open("output/distances.csv") as f:
+        for row in csv.DictReader(f):
+            computed[row["source_id"]] = float(row["distance_pc"])
+
+    reference = {}
+    with open("test/reference_distances.csv") as f:
+        for row in csv.DictReader(f):
+            reference[row["source_id"]] = float(row["distance_gspphot"])
+
+    matched = set(computed) & set(reference)
+    if not matched:
+        print("ERROR: no matching source_ids between computed and reference")
+        sys.exit(1)
+
+    max_pct_err = 0
+    failures = []
+    for sid in sorted(matched):
+        c = computed[sid]
+        r = reference[sid]
+        pct_err = abs(c - r) / r * 100
+        max_pct_err = max(max_pct_err, pct_err)
+        if pct_err > 0.5:
+            failures.append((sid, c, r, pct_err))
+
+    print(f"Compared {len(matched)} stars")
+    print(f"Max error: {max_pct_err:.2f}%")
+
+    if failures:
+        print(f"\nFAILED: {len(failures)} stars differ by >0.5%:")
+        for sid, c, r, pct in failures:
+            print(f"  {sid}: computed={c:.4f} ref={r:.4f} err={pct:.1f}%")
+        sys.exit(1)
+    else:
+        print("PASSED: all within 0.5%")
+
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+# Update Makefile with test target
+printf '.POSIX:\n\nall: output/distances.csv\n\nraw/gaia_nearby.csv:\n\tpython3 code/fetch_data.py raw/gaia_nearby.csv\n\noutput/distances.csv: raw/gaia_nearby.csv code/compute_distances.py\n\tpython3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv\n\ntest: output/distances.csv\n\t./test/fetch_reference_distances.sh\n\tpython3 test/verify_distances.py\n\nclean:\n\trm -f output/distances.csv\n\n.PHONY: all test clean\n' > Makefile
+
+cat > .gitignore <<'GI'
+.venv/
+test/reference_distances.csv
+GI
+
+cat > README.md <<'README'
+# Stellar Distance from Gaia Parallax
+
+Compute distances to nearby stars using parallax measurements from the
+[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
+
+**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
+**Output**: Source IDs and computed distances (parsecs).
+**Method**: `distance_pc = 1000 / parallax_mas`
+
+## Reproduce
+
+    make
+
+## Verify
+
+    make test
+README
+
+git add test/ Makefile .gitignore README.md
+git commit -m "Add verification test against Gaia GSP-Phot reference distances"
+
+make test
+```
 
 We write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
 `make test` runs it.
@@ -261,10 +587,67 @@ stellar-distance/
 
 ### 8. Declare and pin dependencies
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+cat > code/fetch_data.py <<'PYEOF'
+#!/usr/bin/env python3
+"""Fetch nearby star parallax data from Gaia DR3 via TAP query."""
+
+import requests
+import sys
+
+GAIA_TAP_URL = "https://gea.esac.esa.int/tap-server/tap/sync"
+
+QUERY = """\
+SELECT TOP {limit}
+    source_id, parallax
+FROM gaiadr3.gaia_source
+WHERE parallax > {min_parallax}
+    AND parallax_error / parallax < {max_error_ratio}
+ORDER BY parallax DESC
+"""
+
+
+def fetch(output_path, limit=100, min_parallax=10, max_error_ratio=0.1):
+    query = QUERY.format(
+        limit=limit,
+        min_parallax=min_parallax,
+        max_error_ratio=max_error_ratio,
+    )
+    resp = requests.get(GAIA_TAP_URL, params={
+        "REQUEST": "doQuery",
+        "LANG": "ADQL",
+        "FORMAT": "csv",
+        "QUERY": query,
+    })
+    resp.raise_for_status()
+
+    with open(output_path, "w") as f:
+        f.write(resp.text)
+
+    n_stars = resp.text.count("\n") - 1
+    print(f"Fetched {n_stars} stars -> {output_path}")
+
+
+if __name__ == "__main__":
+    output = sys.argv[1] if len(sys.argv) > 1 else "raw/gaia_nearby.csv"
+    fetch(output)
+PYEOF
+
+cat > pyproject.toml <<'TOML'
+[project]
+name = "stellar-distance"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "requests",
+]
+TOML
+```
+
 Until now the scripts used only Python's standard library (urllib, csv), so there was nothing to declare.
 To demonstrate how dependencies are handled, we rewrite the fetch script to use `requests`:
-
-<!-- TODO: link to fetch_data.py rewrite commit once repo history is restructured -->
 
 ```python
 # fetch_data.py (abbreviated)
@@ -289,7 +672,39 @@ dependencies = ["requests"]
 ```
 
 ```sh
+# pragma: testrun full-build
 pip-compile --generate-hashes -o requirements.txt pyproject.toml
+```
+
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+cat > README.md <<'README'
+# Stellar Distance from Gaia Parallax
+
+Compute distances to nearby stars using parallax measurements from the
+[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
+
+**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
+**Output**: Source IDs and computed distances (parsecs).
+**Method**: `distance_pc = 1000 / parallax_mas`
+
+## Reproduce
+
+    make
+
+## Verify
+
+    make test
+
+## Requirements
+
+- Python >= 3.10
+- Dependencies declared in `pyproject.toml`; install with `pip install -r requirements.txt`
+README
+
+git add code/fetch_data.py pyproject.toml requirements.txt README.md
+git commit -m "Rewrite fetch with requests, declare and pin dependencies"
 ```
 
 There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
@@ -301,6 +716,38 @@ This is where Portability meets Tracking: the environment specification itself i
 **Advances**: P (host assumptions documented, reproducible environment), T (pinned versions are content-addressed)
 
 ### 9. Reproduce from scratch
+
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+cat > test/reproduce_from_scratch.sh <<'TESTSH'
+#!/bin/sh
+# Reproduce the full pipeline from a clean clone in a temp directory.
+set -eux
+PS4='> '
+
+repo_url="${1:?Usage: $0 <repo-url-or-path>}"
+
+cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
+echo "Working in: $(pwd)"
+
+git clone "$repo_url" stellar-distance
+cd stellar-distance
+
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+make
+make test
+
+echo "=== PASSED: reproduced from scratch ==="
+TESTSH
+chmod +x test/reproduce_from_scratch.sh
+
+git add test/reproduce_from_scratch.sh
+git commit -m "Add ephemeral reproduction script"
+```
 
 We write `test/reproduce_from_scratch.sh` — a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -58,6 +58,7 @@ cd stellar-distance
 git config user.email "demo@example.com"
 git config user.name "Demo User"
 
+# snippet: compute-everything
 cat > compute_everything.py <<'PYEOF'
 #!/usr/bin/env python3
 """Quick proof of concept: fetch Gaia parallax data and compute distances."""
@@ -95,6 +96,7 @@ with open("distances.csv", "w", newline="") as f:
 
 print("Done — wrote distances.csv")
 PYEOF
+# /snippet
 
 python3 compute_everything.py
 git add compute_everything.py distances.csv
@@ -147,6 +149,7 @@ Each step that follows addresses one of these failure modes.
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
+# snippet: fetch-data
 cat > fetch_data.py <<'PYEOF'
 #!/usr/bin/env python3
 """Fetch nearby star parallax data from Gaia DR3 via TAP query."""
@@ -193,7 +196,9 @@ if __name__ == "__main__":
     output = sys.argv[1] if len(sys.argv) > 1 else "gaia_nearby.csv"
     fetch(output)
 PYEOF
+# /snippet
 
+# snippet: compute-distances
 cat > compute_distances.py <<'PYEOF'
 #!/usr/bin/env python3
 """Compute stellar distances from Gaia parallax measurements."""
@@ -223,6 +228,7 @@ def main(input_path, output_path):
 if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2])
 PYEOF
+# /snippet
 
 git rm compute_everything.py
 git rm distances.csv
@@ -365,6 +371,7 @@ Anyone can inspect the commit messages to see exactly how each file was produced
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
+# snippet: readme
 cat > README.md <<'README'
 # Stellar Distance from Gaia Parallax
 
@@ -380,6 +387,7 @@ Compute distances to nearby stars using parallax measurements from the
     python3 code/fetch_data.py raw/gaia_nearby.csv
     python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
 README
+# /snippet
 
 git add README.md
 git commit -m "Add README with reproduction instructions"
@@ -415,7 +423,24 @@ This is the minimum viable Actionability (A.1): sufficient instructions to repro
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
-printf '.POSIX:\n\nall: output/distances.csv\n\nraw/gaia_nearby.csv:\n\tpython3 code/fetch_data.py raw/gaia_nearby.csv\n\noutput/distances.csv: raw/gaia_nearby.csv code/compute_distances.py\n\tpython3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv\n\nclean:\n\trm -f output/distances.csv\n\n.PHONY: all clean\n' > Makefile
+# snippet: makefile
+cat > Makefile <<'MAKE'
+.POSIX:
+
+all: output/distances.csv
+
+raw/gaia_nearby.csv:
+	python3 code/fetch_data.py raw/gaia_nearby.csv
+
+output/distances.csv: raw/gaia_nearby.csv code/compute_distances.py
+	python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
+
+clean:
+	rm -f output/distances.csv
+
+.PHONY: all clean
+MAKE
+# /snippet
 
 # Update README: replace manual commands with 'make'
 sed -i '/^    python3 code\/fetch_data\.py/,/^    python3 code\/compute_distances\.py/c\    make' README.md
@@ -453,6 +478,7 @@ Now `make` is the single command to reproduce everything. We update the README a
 # pragma: render hidden
 mkdir -p test
 
+# snippet: fetch-reference
 cat > test/fetch_reference_distances.sh <<'TESTSH'
 #!/bin/sh
 # Fetch GSP-Phot reference distances for the exact stars we computed
@@ -469,8 +495,10 @@ curl -s -o test/reference_distances.csv \
 
 echo "Fetched $(tail -n +2 test/reference_distances.csv | wc -l) reference distances"
 TESTSH
+# /snippet
 chmod +x test/fetch_reference_distances.sh
 
+# snippet: verify-distances
 cat > test/verify_distances.py <<'PYEOF'
 #!/usr/bin/env python3
 """Compare our computed distances against Gaia GSP-Phot reference distances."""
@@ -520,6 +548,7 @@ def main():
 if __name__ == "__main__":
     main()
 PYEOF
+# /snippet
 
 # Add test target to Makefile
 sed -i 's/^\.PHONY: all clean/.PHONY: all test clean/' Makefile
@@ -585,6 +614,7 @@ stellar-distance/
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
+# snippet: fetch-data-requests
 cat > code/fetch_data.py <<'PYEOF'
 #!/usr/bin/env python3
 """Fetch nearby star parallax data from Gaia DR3 via TAP query."""
@@ -629,7 +659,9 @@ if __name__ == "__main__":
     output = sys.argv[1] if len(sys.argv) > 1 else "raw/gaia_nearby.csv"
     fetch(output)
 PYEOF
+# /snippet
 
+# snippet: pyproject
 cat > pyproject.toml <<'TOML'
 [project]
 name = "stellar-distance"
@@ -639,6 +671,7 @@ dependencies = [
     "requests",
 ]
 TOML
+# /snippet
 ```
 
 Until now the scripts used only Python's standard library (urllib, csv), so there was nothing to declare.
@@ -701,6 +734,7 @@ This is where Portability meets Tracking: the environment specification itself i
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
+# snippet: reproduce
 cat > test/reproduce_from_scratch.sh <<'TESTSH'
 #!/bin/sh
 # Reproduce the full pipeline from a clean clone in a temp directory.
@@ -724,6 +758,7 @@ make test
 
 echo "=== PASSED: reproduced from scratch ==="
 TESTSH
+# /snippet
 chmod +x test/reproduce_from_scratch.sh
 
 git add test/reproduce_from_scratch.sh

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -99,6 +99,7 @@ PYEOF
 python3 compute_everything.py
 git add compute_everything.py distances.csv
 git commit -m "Initial analysis: compute stellar distances"
+git tag stellar-step-1
 ```
 
 We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
@@ -259,6 +260,12 @@ datalad run \
   "python3 fetch_data.py gaia_nearby.csv"
 ```
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+git tag stellar-step-2
+```
+
 This records exactly what command produced the data, creating a machine-readable provenance record in the commit message.
 The data is no longer just "a CSV that appeared somehow" — it has a documented origin that anyone can inspect and replay with `datalad rerun`.
 
@@ -295,6 +302,7 @@ git mv compute_distances.py code/
 git mv gaia_nearby.csv raw/
 git mv distances.csv output/
 git commit -m "Organize into code/, raw/, output/"
+git tag stellar-step-3
 ```
 
 We create `code/`, `raw/`, and `output/` directories, and move each file to where it belongs:
@@ -340,6 +348,12 @@ datalad run \
   "python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv"
 ```
 
+```sh
+# pragma: testrun full-build
+# pragma: render hidden
+git tag stellar-step-4
+```
+
 The `-i` flags declare inputs and `-o` declares outputs.
 Now the full pipeline — from raw data to final results — has machine-readable provenance.
 Anyone can inspect the commit messages to see exactly how each file was produced.
@@ -369,6 +383,7 @@ README
 
 git add README.md
 git commit -m "Add README with reproduction instructions"
+git tag stellar-step-5
 ```
 
 We add a README explaining what this project does, what the inputs and outputs are, and how to run it:
@@ -407,6 +422,7 @@ sed -i '/^    python3 code\/fetch_data\.py/,/^    python3 code\/compute_distance
 
 git add Makefile README.md
 git commit -m "Add Makefile encoding the full pipeline"
+git tag stellar-step-6
 ```
 
 We encode the pipeline as `make` targets with their dependencies:
@@ -524,6 +540,7 @@ README
 
 git add test/ Makefile .gitignore README.md
 git commit -m "Add verification test against Gaia GSP-Phot reference distances"
+git tag stellar-step-7
 
 make test
 ```
@@ -668,6 +685,7 @@ README
 
 git add code/fetch_data.py pyproject.toml requirements.txt README.md
 git commit -m "Rewrite fetch with requests, declare and pin dependencies"
+git tag stellar-step-8
 ```
 
 There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
@@ -710,6 +728,7 @@ chmod +x test/reproduce_from_scratch.sh
 
 git add test/reproduce_from_scratch.sh
 git commit -m "Add ephemeral reproduction script"
+git tag stellar-step-9
 ```
 
 We write `test/reproduce_from_scratch.sh` — a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -275,8 +275,7 @@ It creates a normal git commit whose message includes a machine-readable run rec
 stellar-distance/
 ├── compute_distances.py
 ├── fetch_data.py
-├── gaia_nearby.csv
-└── distances.csv
+└── gaia_nearby.csv
 ```
 
 **Advances**: T (programmatic provenance), S (versioned local copy of external data), A (provenance is re-executable)
@@ -877,7 +876,7 @@ graph TD
         style E stroke-dasharray: 5 5
         E2["ephemeral clone<br/>(verify reproducibility)"]
         style E2 stroke-dasharray: 5 5
-        P -- "code/reproduce_from_scratch.sh $PWD" --> E
+        P -- "test/reproduce_from_scratch.sh $PWD" --> E
     end
     subgraph sharing and archival
         direction LR

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -402,20 +402,8 @@ This is the minimum viable Actionability (A.1): sufficient instructions to repro
 # pragma: render hidden
 printf '.POSIX:\n\nall: output/distances.csv\n\nraw/gaia_nearby.csv:\n\tpython3 code/fetch_data.py raw/gaia_nearby.csv\n\noutput/distances.csv: raw/gaia_nearby.csv code/compute_distances.py\n\tpython3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv\n\nclean:\n\trm -f output/distances.csv\n\n.PHONY: all clean\n' > Makefile
 
-cat > README.md <<'README'
-# Stellar Distance from Gaia Parallax
-
-Compute distances to nearby stars using parallax measurements from the
-[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
-
-**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
-**Output**: Source IDs and computed distances (parsecs).
-**Method**: `distance_pc = 1000 / parallax_mas`
-
-## Reproduce
-
-    make
-README
+# Update README: replace manual commands with 'make'
+sed -i '/^    python3 code\/fetch_data\.py/,/^    python3 code\/compute_distances\.py/c\    make' README.md
 
 git add Makefile README.md
 git commit -m "Add Makefile encoding the full pipeline"
@@ -517,27 +505,17 @@ if __name__ == "__main__":
     main()
 PYEOF
 
-# Update Makefile with test target
-printf '.POSIX:\n\nall: output/distances.csv\n\nraw/gaia_nearby.csv:\n\tpython3 code/fetch_data.py raw/gaia_nearby.csv\n\noutput/distances.csv: raw/gaia_nearby.csv code/compute_distances.py\n\tpython3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv\n\ntest: output/distances.csv\n\t./test/fetch_reference_distances.sh\n\tpython3 test/verify_distances.py\n\nclean:\n\trm -f output/distances.csv\n\n.PHONY: all test clean\n' > Makefile
+# Add test target to Makefile
+sed -i 's/^\.PHONY: all clean/.PHONY: all test clean/' Makefile
+printf '\ntest: output/distances.csv\n\t./test/fetch_reference_distances.sh\n\tpython3 test/verify_distances.py\n' >> Makefile
 
 cat > .gitignore <<'GI'
 .venv/
 test/reference_distances.csv
 GI
 
-cat > README.md <<'README'
-# Stellar Distance from Gaia Parallax
-
-Compute distances to nearby stars using parallax measurements from the
-[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
-
-**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
-**Output**: Source IDs and computed distances (parsecs).
-**Method**: `distance_pc = 1000 / parallax_mas`
-
-## Reproduce
-
-    make
+# Append Verify section to README
+cat >> README.md <<'README'
 
 ## Verify
 
@@ -679,23 +657,8 @@ pip-compile --generate-hashes -o requirements.txt pyproject.toml
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
-cat > README.md <<'README'
-# Stellar Distance from Gaia Parallax
-
-Compute distances to nearby stars using parallax measurements from the
-[Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
-
-**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
-**Output**: Source IDs and computed distances (parsecs).
-**Method**: `distance_pc = 1000 / parallax_mas`
-
-## Reproduce
-
-    make
-
-## Verify
-
-    make test
+# Append Requirements section to README
+cat >> README.md <<'README'
 
 ## Requirements
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -36,19 +36,20 @@ cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
 ## What we're building
 
 Most research code starts the same way: a script that works, on your machine, right now.
-That's not a problem — it's a starting point.
+That's a starting point.
 
-Here we take a real analysis — computing distances to nearby stars from European Space Agency data — and gradually turn it into something anyone can verify, reproduce, and build on.
+Here we take a real analysis (computing distances to nearby stars from European Space Agency data) and gradually turn it into something anyone can verify, reproduce, and build on.
 No new frameworks.
 No heavyweight infrastructure.
 Just a series of small, practical steps, each one solving a concrete problem: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
 
 Along the way, we note which STAMPED properties each step improves.
-By the end, we have a research object that passes a from-scratch reproduction test in a throwaway directory — and most of the steps turn out to be things we might already be doing, just named and organized.
+By the end, we have a research object that passes a from-scratch reproduction test in a throwaway directory.
+Most of the steps turn out to be things we might already be doing, just named and organized.
 
 **The science**: we compute the distance to 100 nearby stars using parallax measurements from the [Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
 The math is one line: `distance_pc = 1000 / parallax_mas`.
-The result is a CSV of stellar distances in parsecs — verified against Gaia's own pipeline estimates to within 0.3%.
+The result is a CSV of stellar distances in parsecs, verified against Gaia's own pipeline estimates to within 0.3%.
 
 The analysis is deliberately simple so the focus stays on *how* we organize, track, and share the work.
 
@@ -234,25 +235,14 @@ git add fetch_data.py compute_distances.py
 git commit -m "Split into fetch and compute scripts"
 ```
 
-The monolithic script does two things — fetch and compute — and there's no way to re-run one without the other.
+The monolithic script does two things (fetch and compute) and there's no way to re-run one without the other.
 We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `compute_distances.py` to calculate distances from that data.
 
-```python
-# fetch_data.py (abbreviated)
-def fetch(output_path):
-    # ... query Gaia TAP API with urllib ...
-    with open(output_path, "w") as f:
-        f.write(data)
-```
+{{< snippet id="fetch-data" lang="python" lines="1-2,20,35-36" >}}
 
-```python
-# compute_distances.py (abbreviated)
-def main(input_path, output_path):
-    # ... read input CSV ...
-    for star in stars:
-        distance_pc = 1000.0 / float(star["parallax"])
-    # ... write output CSV ...
-```
+{{< snippet id="compute-distances" lang="python" lines="1-2,8,16-17" >}}
+
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-2)
 
 Now we do something important: instead of just running `fetch_data.py`, we wrap it with `datalad run`:
 
@@ -271,14 +261,14 @@ git tag stellar-step-2
 ```
 
 This records exactly what command produced the data, creating a machine-readable provenance record in the commit message.
-The data is no longer just "a CSV that appeared somehow" — it has a documented origin that anyone can inspect and replay with `datalad rerun`.
+The data is no longer just "a CSV that appeared somehow." It has a documented origin that anyone can inspect and replay with `datalad rerun`.
 
 This also addresses a Self-containment concern.
 Our analysis depends on an external network resource (the Gaia TAP API), which means it could break if the API changes or goes offline.
 Once we've fetched the data with `datalad run`, we have our own versioned copy.
-The API is still the authoritative source, but we're no longer silently dependent on it — the provenance record documents where the data came from, and the committed CSV means the analysis can proceed offline.
+The API is still the authoritative source, but we're no longer silently dependent on it. The provenance record documents where the data came from, and the committed CSV means the analysis can proceed offline.
 
-`datalad run` works on plain git repositories — no special initialization required.
+`datalad run` works on plain git repositories. No special initialization required.
 It creates a normal git commit whose message includes a machine-readable run record (the command, inputs, and outputs), so `git log` still tells the whole story.
 
 ```
@@ -326,7 +316,9 @@ Code is what we write, raw is what we fetch, output is what we compute.
 The role of each file is obvious at a glance.
 When something breaks, we know where to look.
 
-This is Modularity at its simplest — not separate repositories, just separate directories with clear roles.
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-3)
+
+This is Modularity at its simplest: not separate repositories, just separate directories with clear roles.
 
 **Advances**: M (logical separation of concerns), S (clearer boundary)
 
@@ -359,8 +351,10 @@ git tag stellar-step-4
 ```
 
 The `--input` flags declare inputs and `--output` declares outputs.
-Now the full pipeline — from raw data to final results — has machine-readable provenance.
+Now the full pipeline, from raw data to final results, has machine-readable provenance.
 Anyone can inspect the commit messages to see exactly how each file was produced.
+
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-4)
 
 **Advances**: T (full pipeline provenance), A (analysis is re-executable via `datalad rerun`)
 
@@ -394,23 +388,11 @@ git tag stellar-step-5
 
 We add a README explaining what this project does, what the inputs and outputs are, and how to run it:
 
-```markdown
-# Stellar Distance from Gaia Parallax
+{{< snippet id="readme" lang="markdown" >}}
 
-Compute distances to nearby stars using parallax measurements from the
-Gaia DR3 catalog.
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-5)
 
-**Input**: Gaia source IDs and parallax (milliarcseconds), fetched via TAP query.
-**Output**: Source IDs and computed distances (parsecs).
-**Method**: `distance_pc = 1000 / parallax_mas`
-
-## Reproduce
-
-    python3 code/fetch_data.py raw/gaia_nearby.csv
-    python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
-```
-
-Without a README, the project is only usable by the person who wrote it — and only while they remember how.
+Without a README, the project is only usable by the person who wrote it, and only while they remember how.
 A README makes it usable by anyone who can read.
 This is the minimum viable Actionability (A.1): sufficient instructions to reproduce all results.
 
@@ -450,24 +432,18 @@ git tag stellar-step-6
 
 We encode the pipeline as `make` targets with their dependencies:
 
-```makefile
-all: output/distances.csv
+{{< snippet id="makefile" lang="makefile" >}}
 
-raw/gaia_nearby.csv:
-	python3 code/fetch_data.py raw/gaia_nearby.csv
-
-output/distances.csv: raw/gaia_nearby.csv code/compute_distances.py
-	python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
-```
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-6)
 
 The README *says* how to run the pipeline.
 The Makefile *does* it.
-This is the jump from documented to executable — the Actionability spectrum in action (A.2).
+This is the jump from documented to executable: the Actionability spectrum in action (A.2).
 Make also encodes dependencies: it knows what to re-run when an input changes, which is itself a lightweight form of provenance.
 
 Now `make` is the single command to reproduce everything. We update the README accordingly.
 
-**Advances**: A (executable specification — not just documentation but a runnable recipe)
+**Advances**: A (executable specification, a runnable recipe)
 
 ### 7. Add a test
 
@@ -573,7 +549,10 @@ make test
 ```
 
 We write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
-`make test` runs it.
+
+{{< snippet id="verify-distances" lang="python" lines="1-2,8,19,26-31,34-35,43" >}}
+
+We add a `test` target to the Makefile so `make test` runs it:
 
 ```
 $ make test
@@ -583,8 +562,10 @@ Max error: 0.27%
 PASSED: all within 0.5%
 ```
 
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-7)
+
 Without verification, a research object asks others to trust the results.
-A test makes the claim falsifiable — anyone can run `make test` and see for themselves.
+A test makes the claim falsifiable: anyone can run `make test` and see for themselves.
 
 Only 48 of our 100 stars have GSP-Phot distances because Gaia's sophisticated pipeline doesn't produce estimates for every star.
 Our simple one-line formula actually covers more stars than the pipeline does.
@@ -675,27 +656,13 @@ TOML
 Until now the scripts used only Python's standard library (urllib, csv), so there was nothing to declare.
 To demonstrate how dependencies are handled, we rewrite the fetch script to use `requests`:
 
-```python
-# fetch_data.py (abbreviated)
-import requests
+{{< snippet id="fetch-data-requests" lang="python" lines="1-5,19,25-31" >}}
 
-def fetch(output_path, ...):
-    resp = requests.get(GAIA_TAP_URL, params={...})
-    # ... write resp.text to output_path ...
-```
-
-Without declaring the dependency, a fresh machine fails with `ModuleNotFoundError` — a Portability failure that only surfaces when someone else tries to run the code.
+Without declaring the dependency, a fresh machine fails with `ModuleNotFoundError`. This is a Portability failure that only surfaces when someone else tries to run the code.
 
 We add `pyproject.toml` to make the assumption explicit, then generate a hash-locked `requirements.txt`:
 
-```toml
-# pyproject.toml
-[project]
-name = "stellar-distance"
-version = "0.1.0"
-requires-python = ">=3.10"
-dependencies = ["requests"]
-```
+{{< snippet id="pyproject" lang="toml" >}}
 
 ```sh
 # pragma: testrun full-build
@@ -720,10 +687,12 @@ git tag stellar-step-8
 ```
 
 There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
-The first is a declaration — it says what we need.
-The second is a distribution-ready specification — it says exactly what bytes to install.
+The first is a declaration: it says what we need.
+The second is a distribution-ready specification: it says exactly what bytes to install.
 Hash pinning means even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
 This is where Portability meets Tracking: the environment specification itself is content-addressed.
+
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-8)
 
 **Advances**: P (host assumptions documented, reproducible environment), T (pinned versions are content-addressed)
 
@@ -764,28 +733,13 @@ git commit -m "Add ephemeral reproduction script"
 git tag stellar-step-9
 ```
 
-We write `test/reproduce_from_scratch.sh` — a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
+We write `test/reproduce_from_scratch.sh`, a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
 
-```sh
-#!/bin/sh
-set -eux
-repo_url="${1:?Usage: $0 <repo-url-or-path>}"
+{{< snippet id="reproduce" lang="sh" >}}
 
-cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
-git clone "$repo_url" stellar-distance
-cd stellar-distance
+[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-9)
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt
-
-make
-make test
-
-echo "=== PASSED: reproduced from scratch ==="
-```
-
-If it passes, the research object doesn't depend on anything from our machine — no accumulated state, no forgotten steps.
+If it passes, the research object doesn't depend on anything from our machine. No accumulated state, no forgotten steps.
 The temp directory is thrown away afterward.
 
 This is the integration test for a research object.
@@ -799,10 +753,10 @@ This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-repro
 
 ### 10. Push to GitHub
 
-We push to a [public repository](https://github.com/asmacdo/STAMPED-stellar-distances).
+We push to a public repository.
 Now anyone can `git clone`, `pip install -r requirements.txt`, `make`, and reproduce the result.
 
-Until this step the research object was self-contained and reproducible — but only on our machine.
+Until this step the research object was self-contained and reproducible, but only on our machine.
 Publishing crosses the Distributability threshold (D.1): all components become persistently retrievable by others.
 
 GitHub is hosting, not archival.
@@ -868,14 +822,16 @@ datalad run \
 ```
 
 The new data is committed with a fresh provenance record.
-Then `datalad rerun` of the analysis step picks up the new input and recomputes distances — the full pipeline adapts to changed inputs without manual re-orchestration.
+Then `datalad rerun` of the analysis step picks up the new input and recomputes distances.
+The full pipeline adapts to changed inputs without manual re-orchestration.
 
 This is where modularity and provenance reinforce each other: because the fetch and analysis steps are recorded separately, we can update one without losing the provenance of the other.
 
 ### Modularity via subdatasets
 
 Right now our modularity is directory-level: `code/`, `raw/`, `output/`.
-That's a good start, but the raw data and the analysis code have different lifecycles — the data might be shared across projects while the analysis code is specific to this one.
+That's a good start, but the raw data and the analysis code have different lifecycles.
+The data might be shared across projects while the analysis code is specific to this one.
 
 DataLad subdatasets take modularity further.
 The raw data could live in its own independently versioned dataset:
@@ -890,13 +846,14 @@ The parent dataset records which exact version of each subdataset it depends on,
 ### Containers for portability and ephemerality
 
 A Dockerfile (pinned by image digest) freezes the OS and Python version.
-Running the pipeline inside a disposable container validates that the specifications are complete — if it works in a fresh container, it's not relying on anything from our machine.
+Running the pipeline inside a disposable container validates that the specifications are complete.
+If it works in a fresh container, it's not relying on anything from our machine.
 See [Container venv overlay for Python development]({{< ref "examples/container-venv-overlay-development" >}}) for a detailed treatment of this pattern.
 
 ### CI for ephemeral validation
 
 A GitHub Actions workflow that clones, installs, and runs `make test` on every push.
-This catches environment drift automatically — the ephemeral reproduction test from step 9, run by someone else's machine on every change.
+This catches environment drift automatically: the same ephemeral test from step 9, run by someone else's machine on every change.
 
 ### Archival distribution
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -43,7 +43,7 @@ No new frameworks.
 No heavyweight infrastructure.
 Just a series of small, practical steps, each one solving a concrete problem: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
 
-Along the way, we note which [STAMPED]({{< ref "principles" >}}) properties (Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, Distributable) each step improves.
+Along the way, we note which [STAMPED]({{< ref "stamped_principles" >}}) properties (Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, Distributable) each step improves.
 By the end, we have a research object that passes a from-scratch reproduction test in a throwaway directory.
 Most of the steps turn out to be things we might already be doing, just named and organized.
 
@@ -720,6 +720,7 @@ python3 -m venv .venv
 . .venv/bin/activate
 pip install -r requirements.txt
 
+make clean
 make
 make test
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -18,12 +18,18 @@ params:
 #!/bin/sh
 # pragma: testrun full-build
 # pragma: render hidden
-# pragma: requires sh git python3 curl make pip-compile datalad
+# pragma: requires sh git python3 curl make
 # pragma: timeout 600
 # pragma: materialize stellar-distance
 
 set -eux
 PS4='> '
+
+# Build environment — tools needed by later steps
+python3 -m venv "${TMPDIR:-/tmp}/.build-env"
+. "${TMPDIR:-/tmp}/.build-env/bin/activate"
+pip install pip-tools datalad requests
+
 cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
 ```
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -39,8 +39,25 @@ The analysis is deliberately simple so the focus stays on *how* we organize, tra
 
 ### 1. Proof of concept
 
-We start with a single Python script that queries the Gaia TAP API, fetches parallax for 100 nearby stars, computes `distance_pc = 1000 / parallax`, and writes a CSV.
-Run it, get a result, done.
+We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
+
+```python
+# compute_everything.py (abbreviated)
+QUERY = (
+    "SELECT TOP 100 source_id, parallax "
+    "FROM gaiadr3.gaia_source "
+    "WHERE parallax > 10 AND parallax_error/parallax < 0.1 "
+    "ORDER BY parallax DESC"
+)
+
+# ... fetch from Gaia TAP API ...
+
+for star in reader:
+    distance_pc = 1000.0 / float(star["parallax"])
+```
+
+Run it, get a `distances.csv` with 100 rows, done.
+Proxima Centauri shows up at ~1.30 parsecs — looks right.
 
 This is where most analyses live forever — and that's fine for exploration.
 But what happens when we come back in six months and can't remember which query parameters we used?
@@ -49,34 +66,116 @@ When a reviewer asks us to recompute with updated data?
 
 Each step that follows addresses one of these failure modes.
 
-*We committed this so it's visible in the repo, but in real life this might just be a loose file on the desktop.*
+**Commit**: [TODO]
 
-**Commit**: [`0d95ecc`](0d95ecc)
+### 2. Gather and start tracking
 
-### 2. Gather everything under one roof
+We put everything in a single project directory and run `git init`.
 
-We put all the files in a single project directory.
+Two things happen at once here: we draw a boundary around the project (Self-containment), and we start recording its history (Tracking).
+The boundary is the "don't look up" rule (S.1): everything needed for this work lives inside one root, and nothing outside should be implicitly required.
+Git gives us content-addressed version control — each commit hash is a cryptographic fingerprint of the entire project state, not an ambiguous label like "version 1.0."
 
-This sounds obvious, but it's the foundation everything else builds on.
-Right now the script and its output are loose — a collaborator would need to know which ones go together.
-A project directory draws a boundary: everything inside is part of this work, nothing outside should be needed.
-STAMPED calls this the "don't look up" rule (S.1): a research object must never rely on implicit external state.
+From now on, every change is recorded and reversible.
+That makes all subsequent steps low-risk.
 
-**Advances**: S (everything reachable from one root)
+**Advances**: S (everything reachable from one root), T (content identification, change history)
 
-### 3. Organize into directories
+**Commit**: [TODO]
 
-We separate `code/`, `raw/`, and `output/`, and split the monolithic script into two: one that fetches data, one that computes distances.
+### 3. Split the script and fetch data with provenance
 
-Now the role of each file is obvious at a glance — code is what we write, raw is what we fetch, output is what we compute.
+The monolithic script does two things — fetch and compute — and there's no way to re-run one without the other.
+We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `compute_distances.py` to calculate distances from that data.
+
+```python
+# fetch_data.py
+def fetch(output_path):
+    params = urllib.parse.urlencode({
+        "REQUEST": "doQuery", "LANG": "ADQL", "FORMAT": "csv",
+        "QUERY": QUERY,
+    })
+    with urllib.request.urlopen(f"{GAIA_TAP_URL}?{params}") as resp:
+        data = resp.read().decode()
+    with open(output_path, "w") as f:
+        f.write(data)
+```
+
+```python
+# compute_distances.py
+def main(input_path, output_path):
+    # ... read input CSV ...
+    for star in stars:
+        distance_pc = 1000.0 / float(star["parallax"])
+    # ... write output CSV ...
+```
+
+Now we do something important: instead of just running `fetch_data.py`, we wrap it with `datalad run`:
+
+```sh
+datalad run \
+  -m "Fetch 100 nearest stars from Gaia DR3" \
+  -o "gaia_nearby.csv" \
+  "python3 fetch_data.py gaia_nearby.csv"
+```
+
+This records exactly what command produced the data, creating a machine-readable provenance record in the commit message.
+The data is no longer just "a CSV that appeared somehow" — it has a documented origin that anyone can inspect and replay with `datalad rerun`.
+
+This also addresses a Self-containment concern.
+Our analysis depends on an external network resource (the Gaia TAP API), which means it could break if the API changes or goes offline.
+Once we've fetched the data with `datalad run`, we have our own versioned copy.
+The API is still the authoritative source, but we're no longer silently dependent on it — the provenance record documents where the data came from, and the committed CSV means the analysis can proceed offline.
+
+`datalad run` works on plain git repositories — no special initialization required.
+
+**Advances**: T (programmatic provenance), S (versioned local copy of external data), A (provenance is re-executable)
+
+**Commits**: [TODO] (split scripts), [TODO] (datalad run fetch)
+
+### 4. Organize into directories
+
+We create `code/`, `raw/`, and `output/` directories, and move each file to where it belongs:
+
+```
+code/fetch_data.py
+code/compute_distances.py
+raw/gaia_nearby.csv
+output/distances.csv
+```
+
+Code is what we write, raw is what we fetch, output is what we compute.
+The role of each file is obvious at a glance.
 When something breaks, we know where to look.
-And each piece is independently testable and replaceable — Modularity at its simplest.
+
+This is Modularity at its simplest — not separate repositories, just separate directories with clear roles.
 
 **Advances**: M (logical separation of concerns), S (clearer boundary)
 
-**Commit**: [`5d7c7fc`](5d7c7fc) (steps 2 and 3 combined)
+**Commit**: [TODO]
 
-### 4. Write a README
+### 5. Record the analysis with provenance
+
+Just as we used `datalad run` for the fetch in step 3, we now use it for the analysis:
+
+```sh
+datalad run \
+  -m "Compute distances for 100 nearest stars" \
+  -i "raw/gaia_nearby.csv" \
+  -i "code/compute_distances.py" \
+  -o "output/distances.csv" \
+  "python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv"
+```
+
+The `-i` flags declare inputs and `-o` declares outputs.
+Now the full pipeline — from raw data to final results — has machine-readable provenance.
+Anyone can inspect the commit messages to see exactly how each file was produced.
+
+**Advances**: T (full pipeline provenance), A (analysis is re-executable via `datalad rerun`)
+
+**Commit**: [TODO]
+
+### 6. Write a README
 
 We add a README explaining what this project does, what the inputs and outputs are, and how to run it.
 
@@ -86,26 +185,21 @@ This is the minimum viable Actionability (A.1): sufficient instructions to repro
 
 **Advances**: A (someone can now follow instructions to reproduce), S (project is self-describing)
 
-**Commit**: [`7c92a7f`](7c92a7f)
+**Commit**: [TODO]
 
-### 5. Initialize version control
+### 7. Write a Makefile
 
-`git init`, add everything, first commit.
+We encode the pipeline as `make` targets with their dependencies:
 
-From now on every change is recorded: who, when, what, and (in the commit message) why.
-We can always get back to any previous state.
+```makefile
+all: output/distances.csv
 
-Each commit hash is a fingerprint of the entire project state — not a label like "version 1.0" that two people could apply to different things, but a cryptographic checksum where the same hash means provably the same content.
-This is also the safety net that makes every subsequent step low-risk: if something goes wrong, we revert.
+raw/gaia_nearby.csv:
+	python3 code/fetch_data.py raw/gaia_nearby.csv
 
-**Advances**: T (content identification, change history)
-
-*In the companion repository we initialized git from the start so each step has its own commit. In practice, this is the point where we'd run `git init`.*
-
-### 6. Write a Makefile
-
-We encode the pipeline as `make` targets: `raw/gaia_nearby.csv` depends on `code/fetch_data.py`, `output/distances.csv` depends on the raw data and `code/compute_distances.py`.
-`make` runs the whole thing.
+output/distances.csv: raw/gaia_nearby.csv code/compute_distances.py
+	python3 code/compute_distances.py raw/gaia_nearby.csv output/distances.csv
+```
 
 The README *says* how to run the pipeline.
 The Makefile *does* it.
@@ -114,65 +208,99 @@ Make also encodes dependencies: it knows what to re-run when an input changes, w
 
 **Advances**: A (executable specification — not just documentation but a runnable recipe)
 
-**Commit**: [`84ba4a5`](84ba4a5)
+**Commit**: [TODO]
 
-### 7. Add a test
+### 8. Add a test
 
 We write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
 `make test` runs it.
-48 of our 100 stars have reference values; all match within 0.3%.
+
+```
+$ make test
+Fetched 48 reference distances
+Compared 48 stars
+Max error: 0.27%
+PASSED: all within 0.5%
+```
 
 Without verification, a research object asks others to trust the results.
 A test makes the claim falsifiable — anyone can run `make test` and see for themselves.
 
-An interesting detail: only 48 stars have GSP-Phot distances because Gaia's sophisticated pipeline doesn't produce estimates for every star.
+Only 48 of our 100 stars have GSP-Phot distances because Gaia's sophisticated pipeline doesn't produce estimates for every star.
 Our simple one-line formula actually covers more stars than the pipeline does.
 
 **Advances**: A (verifiable results, not just "trust me")
 
-**Commit**: [`2a6cd40`](2a6cd40)
+**Commit**: [TODO]
 
-### 8. Declare dependencies
+### 9. Declare and pin dependencies
 
-We add `pyproject.toml` listing the Python packages we use.
+We add `pyproject.toml` listing the Python packages we use, then generate a hash-locked `requirements.txt`:
+
+```toml
+# pyproject.toml
+[project]
+name = "stellar-distance"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["requests"]
+```
+
+```sh
+pip-compile --generate-hashes -o requirements.txt pyproject.toml
+```
 
 Until now the scripts used only Python's standard library.
 When we rewrote the fetch script to use `requests` (cleaner API, better error handling), we introduced an external dependency.
-Without declaring it, a fresh machine fails with `ModuleNotFoundError: No module named 'requests'` — a Portability failure that only surfaces when someone else tries to run the code.
-`pyproject.toml` makes that assumption explicit.
+Without declaring it, a fresh machine fails with `ModuleNotFoundError` — a Portability failure that only surfaces when someone else tries to run the code.
 
-**Advances**: P (host assumptions are now documented, not implicit)
-
-**Commit**: [`ed1900b`](ed1900b)
-
-### 9. Pin dependency versions
-
-We generate `requirements.txt` with exact versions and cryptographic hashes using `pip-compile --generate-hashes`.
-
-There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
+`pyproject.toml` makes the assumption explicit.
+`requirements.txt` with hashes goes further: there's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
 The first is a declaration — it says what we need.
 The second is a distribution-ready specification — it says exactly what bytes to install.
-Hash pinning means that even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
+Hash pinning means even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
 This is where Portability meets Tracking: the environment specification itself is content-addressed.
 
-**Advances**: P (reproducible environment), T (pinned versions are content-addressed)
+**Advances**: P (host assumptions documented, reproducible environment), T (pinned versions are content-addressed)
 
-**Commit**: [`4e63464`](4e63464)
+**Commits**: [TODO] (pyproject.toml), [TODO] (requirements.txt)
 
-### 10. Record provenance with datalad run
+### 10. Reproduce from scratch
 
-We wrap the fetch and analysis commands with `datalad run`, which records the exact command, inputs, and outputs as machine-readable metadata in each commit.
+We write a script that clones the repository into a fresh temp directory, installs dependencies, runs the pipeline, and runs the tests:
 
-A regular git commit says "these files changed."
-A `datalad run` commit says "these files changed *because this command was run with these inputs and produced these outputs*."
-The run record is JSON embedded in the commit message — machine-readable, not just human-readable.
-And because the record is executable, anyone can replay it with `datalad rerun`.
+```sh
+#!/bin/sh
+set -eux
+repo_url="${1:?Usage: $0 <repo-url-or-path>}"
 
-`datalad run` works on plain git repositories — no special dataset initialization or git-annex required.
+cd "$(mktemp -d "${TMPDIR:-/tmp}/stellar-XXXXXXX")"
+git clone "$repo_url" stellar-distance
+cd stellar-distance
 
-**Advances**: T (programmatic provenance), A (provenance records are executable specifications)
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
 
-**Commits**: [`28795f6`](28795f6) (fetch), [`277e8b7`](277e8b7) (compute)
+make
+make test
+
+echo "=== PASSED: reproduced from scratch ==="
+```
+
+If it passes, the research object doesn't depend on anything from our machine — no accumulated state, no forgotten steps.
+The temp directory is thrown away afterward.
+
+This is the integration test for a research object.
+Ephemeral reproduction exercises almost every STAMPED property at once: the project must be self-contained (S), the pipeline must actually run (A), it must work in a fresh environment (P), and there's no prior state to lean on (E).
+If `reproduce_from_scratch.sh` passes, we have strong evidence that the research object is solid.
+If it fails, the error tells us which property broke.
+
+This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-reproducer" >}}) pattern applied to our own project.
+
+**Advances**: E (results produced without prior state), A (reproduction is a single command), S (validates that nothing outside the boundary is needed)
+
+**Commit**: [TODO]
 
 ### 11. Push to GitHub
 
@@ -187,31 +315,14 @@ For long-term persistence the next step would be depositing on Zenodo or Softwar
 
 **Advances**: D (persistently retrievable by others)
 
-**Commit**: [TODO: after GitHub push]
-
-### 12. Reproduce from scratch
-
-We write a script that clones the repository into a fresh temp directory, installs dependencies, runs the pipeline, and runs the tests.
-If it passes, the research object doesn't depend on anything from our machine — no accumulated state, no forgotten steps.
-The temp directory is thrown away afterward.
-
-This is the integration test for a research object.
-Ephemeral reproduction exercises almost every STAMPED property at once: the project must be self-contained (S), the pipeline must actually run (A), it must work in a fresh environment (P), and there's no prior state to lean on (E).
-If `reproduce_from_scratch.sh` passes, we have strong evidence that the research object is solid.
-If it fails, the error tells us which property broke.
-
-This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-reproducer" >}}) pattern applied to our own project.
-
-**Advances**: E (results produced without prior state), A (reproduction is a single command), S (validates that nothing outside the boundary is needed)
-
-**Commit**: [`362ad10`](362ad10)
+**Commit**: [TODO]
 
 ## STAMPED scorecard
 
 | Property | Where we ended up |
 |---|---|
-| **S** Self-contained | All code, data, and instructions under one root. README describes the project. |
-| **T** Tracked | Git tracks all changes. `datalad run` records provenance per computation. Dependencies hash-pinned. |
+| **S** Self-contained | All code, data, and instructions under one root. README describes the project. Versioned local copy of fetched data. |
+| **T** Tracked | Git tracks all changes. `datalad run` records provenance for both fetch and analysis. Dependencies hash-pinned. |
 | **A** Actionable | `make` reproduces results. `make test` verifies. `datalad rerun` replays provenance. README documents the workflow. |
 | **M** Modular | code/, raw/, output/, test/ are logically separated. |
 | **P** Portable | Dependencies declared in pyproject.toml, pinned in requirements.txt with hashes. No hardcoded paths. |
@@ -223,25 +334,60 @@ This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-repro
 Each STAMPED property is a spectrum.
 We've built something solid, but there are natural next steps depending on what the project needs.
 
-**Containers for portability and ephemerality**:
+### Replay and adapt with datalad rerun
+
+Because we recorded provenance with `datalad run`, we can replay the entire pipeline:
+
+```sh
+datalad rerun
+```
+
+This re-executes every recorded command in order.
+But `datalad rerun` really shines when something changes.
+
+Say we want to expand our sample from 100 to 200 stars.
+We update the query parameters in `fetch_data.py`, then re-run just the fetch:
+
+```sh
+datalad run \
+  -m "Fetch 200 nearest stars from Gaia DR3" \
+  -o "raw/gaia_nearby.csv" \
+  "python3 code/fetch_data.py raw/gaia_nearby.csv"
+```
+
+The new data is committed with a fresh provenance record.
+Then `datalad rerun` of the analysis step picks up the new input and recomputes distances — the full pipeline adapts to changed inputs without manual re-orchestration.
+
+This is where modularity and provenance reinforce each other: because the fetch and analysis steps are recorded separately, we can update one without losing the provenance of the other.
+
+### Modularity via subdatasets
+
+Right now our modularity is directory-level: `code/`, `raw/`, `output/`.
+That's a good start, but the raw data and the analysis code have different lifecycles — the data might be shared across projects while the analysis code is specific to this one.
+
+DataLad subdatasets take modularity further.
+The raw data could live in its own independently versioned dataset:
+
+```sh
+datalad clone <data-url> raw/
+```
+
+A colleague running a different analysis on the same stars would `datalad install` the data module rather than re-fetching from the API.
+The parent dataset records which exact version of each subdataset it depends on, so the full research object remains Self-contained and Tracked even as modules evolve independently.
+
+### Containers for portability and ephemerality
+
 A Dockerfile (pinned by image digest) freezes the OS and Python version.
 Running the pipeline inside a disposable container validates that the specifications are complete — if it works in a fresh container, it's not relying on anything from our machine.
 See [Container venv overlay for Python development]({{< ref "examples/container-venv-overlay-development" >}}) for a detailed treatment of this pattern.
 
-**CI for ephemeral validation**:
+### CI for ephemeral validation
+
 A GitHub Actions workflow that clones, installs, and runs `make test` on every push.
-This catches environment drift automatically.
+This catches environment drift automatically — the ephemeral reproduction test from step 10, run by someone else's machine on every change.
 
-**Modularity via subdatasets**:
-The raw data could live in its own DataLad subdataset, independently versioned and reusable.
-A colleague running a different analysis on the same stars would `datalad install` the data module rather than re-fetching from the API.
+### Archival distribution
 
-**Reproducible re-execution**:
-`datalad rerun` replays the recorded provenance.
-If the raw data is updated (say, a new Gaia release), update the input, `datalad rerun`, and the outputs reflect the new data.
-Branches can separate outputs produced from different input versions.
-
-**Archival distribution**:
 Deposit the repository on [Zenodo](https://zenodo.org/) for a DOI.
 Push the container image to a registry.
 Mirror data to multiple remotes so no single point of failure breaks reproducibility.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -844,7 +844,7 @@ stellar-distance/
 | **S** Self-contained | All code, data, and instructions under one root. README describes the project. Versioned local copy of fetched data. |
 | **T** Tracked | Git tracks all changes. `datalad run` records provenance for both fetch and analysis. Dependencies hash-pinned. |
 | **A** Actionable | `make` reproduces results. `make test` verifies. `datalad rerun` replays provenance. README documents the workflow. |
-| **M** Modular | code/, raw/, output/, test/ are logically separated. |
+| **M** Modular | `code/`, `raw/`, `output/`, `test/` are logically separated. |
 | **P** Portable | Dependencies declared in pyproject.toml, pinned in requirements.txt with hashes. No hardcoded paths. |
 | **E** Ephemeral | Reproduction script runs the full pipeline in a fresh temp directory with no prior state. |
 | **D** Distributable | Repository on GitHub. Anyone can clone and reproduce. |

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -43,7 +43,7 @@ No new frameworks.
 No heavyweight infrastructure.
 Just a series of small, practical steps, each one solving a concrete problem: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
 
-Along the way, we note which STAMPED properties each step improves.
+Along the way, we note which [STAMPED]({{< ref "principles" >}}) properties (Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, Distributable) each step improves.
 By the end, we have a research object that passes a from-scratch reproduction test in a throwaway directory.
 Most of the steps turn out to be things we might already be doing, just named and organized.
 
@@ -122,7 +122,7 @@ Proxima Centauri shows up at ~1.30 parsecs. Looks right!
 
 We put the script and its output in a directory and run `git init`.
 Two things happen at once: we draw a boundary around the project (Self-containment), and we start recording its history (Tracking).
-The project boundary is one way to follow the don't look up rule (S.1): everything needed for this work lives inside one root, and nothing outside should be implicitly required.
+The project boundary follows the "don't look up" rule: everything needed for this work lives inside one root, and nothing outside should be implicitly required.
 Git gives us content-addressed version control, so we can track changes over time and identify each project state by its commit.
 
 From now on, every change is recorded and reversible.
@@ -581,6 +581,7 @@ stellar-distance/
 ├── test/
 │   ├── fetch_reference_distances.sh
 │   └── verify_distances.py
+├── .gitignore
 ├── Makefile
 └── README.md
 ```
@@ -774,6 +775,7 @@ stellar-distance/
 │   ├── fetch_reference_distances.sh
 │   ├── verify_distances.py
 │   └── reproduce_from_scratch.sh
+├── .gitignore
 ├── Makefile
 ├── README.md
 ├── pyproject.toml

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -116,7 +116,7 @@ We start with a single Python script that does everything: queries the Gaia TAP 
 
 {{< snippet id="compute-everything" lang="python" lines="1-2,9-15,31-32" >}}
 
-The above is abbreviated. To follow along, see the [full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-1).
+The above is abbreviated. To follow along, see the {{< step-link tag="stellar-step-1" text="full project at this step" >}}.
 
 When we run `python3 compute_everything.py`, we get a `distances.csv` with 100 rows.
 Proxima Centauri shows up at ~1.30 parsecs. Looks right!
@@ -243,7 +243,7 @@ We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `c
 
 {{< snippet id="compute-distances" lang="python" lines="1-2,8,16-17" >}}
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-2)
+{{< step-link tag="stellar-step-2" >}}
 
 Now we do something important: instead of just running `fetch_data.py`, we wrap it with `datalad run`:
 
@@ -316,7 +316,7 @@ Code is what we write, raw is what we fetch, output is what we compute.
 The role of each file is obvious at a glance.
 When something breaks, we know where to look.
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-3)
+{{< step-link tag="stellar-step-3" >}}
 
 This is Modularity at its simplest: not separate repositories, just separate directories with clear roles.
 
@@ -354,7 +354,7 @@ The `--input` flags declare inputs and `--output` declares outputs.
 Now the full pipeline, from raw data to final results, has machine-readable provenance.
 Anyone can inspect the commit messages to see exactly how each file was produced.
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-4)
+{{< step-link tag="stellar-step-4" >}}
 
 **Advances**: T (full pipeline provenance), A (analysis is re-executable via `datalad rerun`)
 
@@ -390,7 +390,7 @@ We add a README explaining what this project does, what the inputs and outputs a
 
 {{< snippet id="readme" lang="markdown" >}}
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-5)
+{{< step-link tag="stellar-step-5" >}}
 
 Without a README, the project is only usable by the person who wrote it, and only while they remember how.
 A README makes it usable by anyone who can read.
@@ -434,7 +434,7 @@ We encode the pipeline as `make` targets with their dependencies:
 
 {{< snippet id="makefile" lang="makefile" >}}
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-6)
+{{< step-link tag="stellar-step-6" >}}
 
 The README *says* how to run the pipeline.
 The Makefile *does* it.
@@ -562,7 +562,7 @@ Max error: 0.27%
 PASSED: all within 0.5%
 ```
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-7)
+{{< step-link tag="stellar-step-7" >}}
 
 Without verification, a research object asks others to trust the results.
 A test makes the claim falsifiable: anyone can run `make test` and see for themselves.
@@ -693,7 +693,7 @@ The second is a distribution-ready specification: it says exactly what bytes to 
 Hash pinning means even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
 This is where Portability meets Tracking: the environment specification itself is content-addressed.
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-8)
+{{< step-link tag="stellar-step-8" >}}
 
 **Advances**: P (host assumptions documented, reproducible environment), T (pinned versions are content-addressed)
 
@@ -739,7 +739,7 @@ We write `test/reproduce_from_scratch.sh`, a script that clones the repository i
 
 {{< snippet id="reproduce" lang="sh" >}}
 
-[Full project at this step](https://github.com/myyoda/principles-examples/tree/stellar-step-9)
+{{< step-link tag="stellar-step-9" >}}
 
 If it passes, the research object doesn't depend on anything from our machine. No accumulated state, no forgotten steps.
 The temp directory is thrown away afterward.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -313,7 +313,7 @@ This is where Portability meets Tracking: the environment specification itself i
 
 ### 9. Reproduce from scratch
 
-We write a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
+We write `test/reproduce_from_scratch.sh` — a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
 
 ```sh
 #!/bin/sh

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -12,6 +12,7 @@ params:
   tools: ["python", "git", "datalad", "make"]
   difficulty: "beginner"
   verified: true
+  materialize_stem: "stellar-distance-walkthrough"
 ---
 
 ```sh
@@ -109,14 +110,13 @@ PYEOF
 python3 compute_everything.py
 git add compute_everything.py distances.csv
 git commit -m "Initial analysis: compute stellar distances"
-git tag stellar-step-1
 ```
 
 We start with a single Python script that does everything: queries the Gaia TAP API, fetches parallax measurements for 100 nearby stars, computes distances, and writes a CSV.
 
 {{< snippet id="compute-everything" lang="python" lines="1-2,9-15,31-32" >}}
 
-The above is abbreviated. To follow along, see the {{< step-link tag="stellar-step-1" text="full project at this step" >}}.
+The above is abbreviated. To follow along, see the {{< step-link step="1" text="full project at this step" >}}.
 
 When we run `python3 compute_everything.py`, we get a `distances.csv` with 100 rows.
 Proxima Centauri shows up at ~1.30 parsecs. Looks right!
@@ -243,7 +243,7 @@ We split it into two scripts: `fetch_data.py` to retrieve data from Gaia, and `c
 
 {{< snippet id="compute-distances" lang="python" lines="1-2,8,16-17" >}}
 
-{{< step-link tag="stellar-step-2" >}}
+{{< step-link step="2" >}}
 
 Now we do something important: instead of just running `fetch_data.py`, we wrap it with `datalad run`:
 
@@ -258,7 +258,6 @@ datalad run \
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
-git tag stellar-step-2
 ```
 
 This records exactly what command produced the data, creating a machine-readable provenance record in the commit message.
@@ -296,7 +295,6 @@ git mv compute_distances.py code/
 git mv gaia_nearby.csv raw/
 git mv distances.csv output/
 git commit -m "Organize into code/, raw/, output/"
-git tag stellar-step-3
 ```
 
 We create `code/`, `raw/`, and `output/` directories, and move each file to where it belongs:
@@ -316,7 +314,7 @@ Code is what we write, raw is what we fetch, output is what we compute.
 The role of each file is obvious at a glance.
 When something breaks, we know where to look.
 
-{{< step-link tag="stellar-step-3" >}}
+{{< step-link step="3" >}}
 
 This is Modularity at its simplest: not separate repositories, just separate directories with clear roles.
 
@@ -347,14 +345,13 @@ datalad run \
 ```sh
 # pragma: testrun full-build
 # pragma: render hidden
-git tag stellar-step-4
 ```
 
 The `--input` flags declare inputs and `--output` declares outputs.
 Now the full pipeline, from raw data to final results, has machine-readable provenance.
 Anyone can inspect the commit messages to see exactly how each file was produced.
 
-{{< step-link tag="stellar-step-4" >}}
+{{< step-link step="4" >}}
 
 **Advances**: T (full pipeline provenance), A (analysis is re-executable via `datalad rerun`)
 
@@ -383,14 +380,13 @@ README
 
 git add README.md
 git commit -m "Add README with reproduction instructions"
-git tag stellar-step-5
 ```
 
 We add a README explaining what this project does, what the inputs and outputs are, and how to run it:
 
 {{< snippet id="readme" lang="markdown" >}}
 
-{{< step-link tag="stellar-step-5" >}}
+{{< step-link step="5" >}}
 
 Without a README, the project is only usable by the person who wrote it, and only while they remember how.
 A README makes it usable by anyone who can read.
@@ -427,14 +423,13 @@ sed -i '/^    python3 code\/fetch_data\.py/,/^    python3 code\/compute_distance
 
 git add Makefile README.md
 git commit -m "Add Makefile encoding the full pipeline"
-git tag stellar-step-6
 ```
 
 We encode the pipeline as `make` targets with their dependencies:
 
 {{< snippet id="makefile" lang="makefile" >}}
 
-{{< step-link tag="stellar-step-6" >}}
+{{< step-link step="6" >}}
 
 The README *says* how to run the pipeline.
 The Makefile *does* it.
@@ -543,7 +538,6 @@ README
 
 git add test/ Makefile .gitignore README.md
 git commit -m "Add verification test against Gaia GSP-Phot reference distances"
-git tag stellar-step-7
 
 make test
 ```
@@ -562,7 +556,7 @@ Max error: 0.27%
 PASSED: all within 0.5%
 ```
 
-{{< step-link tag="stellar-step-7" >}}
+{{< step-link step="7" >}}
 
 Without verification, a research object asks others to trust the results.
 A test makes the claim falsifiable: anyone can run `make test` and see for themselves.
@@ -684,7 +678,6 @@ README
 
 git add code/fetch_data.py pyproject.toml requirements.txt README.md
 git commit -m "Rewrite fetch with requests, declare and pin dependencies"
-git tag stellar-step-8
 ```
 
 There's a big difference between `requests` (any version) and `requests==2.32.5 --hash=sha256:...` (this exact build).
@@ -693,7 +686,7 @@ The second is a distribution-ready specification: it says exactly what bytes to 
 Hash pinning means even if a package is re-uploaded with the same version number, the install rejects it rather than silently using different code.
 This is where Portability meets Tracking: the environment specification itself is content-addressed.
 
-{{< step-link tag="stellar-step-8" >}}
+{{< step-link step="8" >}}
 
 **Advances**: P (host assumptions documented, reproducible environment), T (pinned versions are content-addressed)
 
@@ -732,14 +725,13 @@ chmod +x test/reproduce_from_scratch.sh
 
 git add test/reproduce_from_scratch.sh
 git commit -m "Add ephemeral reproduction script"
-git tag stellar-step-9
 ```
 
 We write `test/reproduce_from_scratch.sh`, a script that clones the repository into a fresh temp directory, creates a virtual environment, installs dependencies, runs the pipeline, and runs the tests:
 
 {{< snippet id="reproduce" lang="sh" >}}
 
-{{< step-link tag="stellar-step-9" >}}
+{{< step-link step="9" >}}
 
 If it passes, the research object doesn't depend on anything from our machine. No accumulated state, no forgotten steps.
 The temp directory is thrown away afterward.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -1,0 +1,209 @@
+---
+title: "Walkthrough: stellar distances from Gaia parallax"
+date: 2026-03-12
+description: "A step-by-step walkthrough building a STAMPED research object that computes stellar distances from Gaia DR3 parallax data"
+summary: "Incrementally builds a research object from a bare script to a tracked, portable, reproducible pipeline — motivated by real problems, not by acronym order."
+tags: ["gaia", "parallax", "walkthrough", "python", "datalad", "make"]
+stamped_principles: ["S", "T", "A", "M", "P", "E", "D"]
+fair_principles: ["R", "A"]
+instrumentation_levels: ["workflow"]
+aspirations: ["reproducibility", "rigor", "transparency"]
+params:
+  tools: ["python", "git", "datalad", "make"]
+  difficulty: "beginner"
+  verified: true
+---
+
+## What we're building
+
+<!-- TODO: wordsmith — enthusiastic intro framing the walkthrough as building a research object, not just running an analysis. Tone: practical, motivating, "you'll be surprised how far simple steps get you." -->
+
+We compute the distance to 100 nearby stars using parallax measurements from the European Space Agency's [Gaia DR3](https://www.cosmos.esa.int/web/gaia/dr3) catalog.
+The math is one line: `distance_pc = 1000 / parallax_mas`.
+The result is a CSV of stellar distances in parsecs — verified against Gaia's own pipeline estimates to within 0.3%.
+
+The analysis is deliberately simple so the focus stays on *how* we organize, track, and share the work.
+Each step is a concrete action.
+We note which STAMPED properties each step improves.
+
+**Repository**: [TODO: link to GitHub repo]
+
+## Steps
+
+### 1. Proof of concept
+
+Write a Python script that queries the Gaia TAP API, fetches parallax for 100 nearby stars, computes `distance_pc = 1000 / parallax`, and writes a CSV.
+Run it. Get a result. Done.
+
+This is where most analyses live forever.
+Not STAMPED at all — but it works, and that matters.
+
+<!-- TODO: expand — frame the tension: the script works but is fragile. What happens when you come back in six months? When a collaborator tries to run it? When a reviewer asks how you got the numbers? Each subsequent step addresses one of these failure modes. -->
+
+*We committed this so you can see it, but in real life this might just be a loose file on your desktop.*
+
+**Commit**: [`0d95ecc`](0d95ecc)
+
+### 2. Gather everything under one roof
+
+Put all files in a single project directory.
+
+<!-- TODO: explain the "don't look up" rule from Self-containment (S.1). Right now the script and output are loose — a collaborator would need to know which files go together. Gathering them establishes a boundary. -->
+
+**Advances**: S (everything reachable from one root)
+
+### 3. Organize into directories
+
+Separate `code/`, `raw/`, `output/`.
+Code is what you write, raw is what you fetch, output is what you compute.
+
+<!-- TODO: explain why separation matters — it tells you the role of each file at a glance. When something breaks, you know where to look. This is Modularity at its simplest: not separate repos, just separate directories with clear roles. Also: splitting the monolithic script into fetch + compute makes each piece independently testable and replaceable. -->
+
+**Advances**: M (logical separation of concerns), S (clearer boundary)
+
+**Commit**: [`5d7c7fc`](5d7c7fc) (steps 2 and 3 combined)
+
+### 4. Write a README
+
+Explain what this project does, what the inputs and outputs are, and how to run it.
+
+<!-- TODO: frame as the minimum viable Actionability. Without a README, the project is only actionable by the person who wrote it (and only while they remember how). A README makes it actionable by anyone who can read. This is A.1: "sufficient instructions to reproduce." -->
+
+**Advances**: A (someone can now follow instructions to reproduce), S (project is self-describing)
+
+**Commit**: [`7c92a7f`](7c92a7f)
+
+### 5. Initialize version control
+
+`git init`. Add everything. First commit.
+
+From now on, every change is recorded: who, when, what, and (in the commit message) why.
+You can always get back to any previous state.
+
+<!-- TODO: explain content-addressed identification (T.1) — each commit hash is a fingerprint of the entire project state. This is stronger than "version 1.0" labels because two people with the same hash provably have the same content. Also: version control is the safety net that makes all subsequent steps low-risk — you can always revert. -->
+
+**Advances**: T (content identification, change history)
+
+*In the companion repository, we initialized git from the start so each step has its own commit. In your own work, this is the point where you'd run `git init`.*
+
+### 6. Write a Makefile
+
+Encode the pipeline as `make` targets: `raw/gaia_nearby.csv` depends on `code/fetch_data.py`, `output/distances.csv` depends on `raw/gaia_nearby.csv` and `code/compute_distances.py`.
+`make` runs the whole thing.
+
+<!-- TODO: frame the jump from "documented" to "executable." The README says how to run the pipeline; the Makefile actually runs it. This is the Actionability spectrum in action (A.2): moving from prose instructions to an executable specification. Also note that Make encodes dependencies — it knows what to re-run when inputs change, which is a form of provenance. -->
+
+**Advances**: A (executable specification — not just documentation but a runnable recipe)
+
+**Commit**: [`84ba4a5`](84ba4a5)
+
+### 7. Add a test
+
+Write a verification script that fetches independent reference distances from Gaia's GSP-Phot pipeline and compares them to our computed values.
+`make test` runs it.
+48 of 100 stars have reference values; all match within 0.3%.
+
+<!-- TODO: explain why testing is Actionability, not just good practice. A research object without verification asks others to trust the results. A test makes the claim falsifiable — anyone can run `make test` and see for themselves. Also note: not all 100 stars have GSP-Phot distances (only 48 do), which actually demonstrates that our simple formula covers more stars than the sophisticated pipeline. -->
+
+**Advances**: A (verifiable results, not just "trust me")
+
+**Commit**: [`2a6cd40`](2a6cd40)
+
+### 8. Declare dependencies
+
+Add `pyproject.toml` listing the Python packages we use (`requests`).
+
+<!-- TODO: frame the problem this solves. Until now, the scripts used only stdlib (urllib). When we rewrote fetch_data.py to use `requests` (cleaner API, better error handling), we introduced an external dependency. Without declaring it, a fresh machine would fail with `ModuleNotFoundError: No module named 'requests'` — a Portability failure. pyproject.toml makes the assumption explicit (P.1, P.2). -->
+
+**Advances**: P (host assumptions are now documented, not implicit)
+
+**Commit**: [`ed1900b`](ed1900b)
+
+### 9. Pin dependency versions
+
+Generate `requirements.txt` with exact versions.
+Better: use `pip-compile --generate-hashes` for hash-pinned versions — guarantees byte-identical packages.
+
+<!-- TODO: explain the difference between "requests" (any version) and "requests==2.32.5 --hash=sha256:..." (this exact build). The former is a declaration; the latter is a distribution-ready specification. Hash pinning means even if a package is re-uploaded with the same version number, the install will fail rather than silently use different code. This is where Portability meets Tracking — the environment specification is content-addressed. -->
+
+**Advances**: P (reproducible environment), T (pinned versions are content-addressed)
+
+**Commit**: [`4e63464`](4e63464)
+
+### 10. Record provenance with datalad run
+
+Wrap the fetch and analysis commands with `datalad run`, which records the exact command, inputs, and outputs as machine-readable metadata in each commit.
+The provenance is not just inspectable — it's re-executable via `datalad rerun`.
+
+Note: `datalad run` works on plain git repositories — no DataLad dataset or git-annex required.
+
+<!-- TODO: explain what datalad run adds beyond "git commit." A regular commit says "these files changed." A datalad run commit says "these files changed because this command was run with these inputs and produced these outputs." The run record is JSON embedded in the commit message — machine-readable, not just human-readable. This is T.4: programmatic provenance that includes component versions. And because the record is executable, it's also A.2: an executable specification. -->
+
+**Advances**: T (programmatic provenance), A (provenance records are executable specifications)
+
+**Commits**: [`28795f6`](28795f6) (fetch), [`277e8b7`](277e8b7) (compute)
+
+### 11. Push to GitHub
+
+`git push` to a public repository.
+Now anyone can `git clone`, `pip install -r requirements.txt`, `make`, and reproduce the result.
+
+<!-- TODO: frame as the Distributability threshold — D.1 says all components must be "persistently retrievable by others." Until this step, the research object was self-contained and reproducible but only on your machine. Publishing makes it distributable. Note: GitHub is not archival — for long-term persistence, Zenodo or Software Heritage would be the next step (see "Where to go from here"). -->
+
+**Advances**: D (persistently retrievable by others)
+
+**Commit**: [TODO: after GitHub push]
+
+### 12. Reproduce from scratch
+
+Write a script that clones the repository into a fresh temp directory, installs dependencies, runs the pipeline, and runs the tests.
+If it passes, the research object doesn't depend on anything from your machine — no accumulated state, no forgotten steps.
+The temp directory is thrown away afterward.
+
+This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-reproducer" >}}) pattern applied to our own project.
+
+<!-- TODO: explain why this is the ultimate integration test for STAMPED. Ephemeral reproduction exercises almost every property at once: S (everything needed must be inside the boundary), A (the pipeline must actually run), P (it must work in a fresh environment), E (no prior state). If reproduce_from_scratch.sh passes, you have strong evidence that your research object is STAMPED. If it fails, the error message tells you exactly which property broke. -->
+
+**Advances**: E (results produced without prior state), A (reproduction is a single command), S (validates that nothing outside the boundary is needed)
+
+**Commit**: [`362ad10`](362ad10)
+
+## STAMPED scorecard
+
+| Property | Where we ended up |
+|---|---|
+| **S** Self-contained | All code, data, and instructions under one root. README describes the project. |
+| **T** Tracked | Git tracks all changes. `datalad run` records provenance per computation. Dependencies hash-pinned. |
+| **A** Actionable | `make` reproduces results. `make test` verifies. `datalad rerun` replays provenance. README documents the workflow. |
+| **M** Modular | code/, raw/, output/, test/ are logically separated. |
+| **P** Portable | Dependencies declared in pyproject.toml, pinned in requirements.txt with hashes. No hardcoded paths. |
+| **E** Ephemeral | Reproduction script runs the full pipeline in a fresh temp directory with no prior state. |
+| **D** Distributable | Repository on GitHub. Anyone can clone and reproduce. |
+
+## Where to go from here
+
+Each STAMPED property is a spectrum.
+We've built something solid, but there are natural next steps depending on what your project needs.
+
+**Containers for portability and ephemerality**:
+A Dockerfile (pinned by image digest) freezes the OS and Python version.
+Running the pipeline inside a disposable container validates that the specifications are complete — if it works in a fresh container, it's not relying on anything from your machine.
+See [Container venv overlay for Python development]({{< ref "examples/container-venv-overlay-development" >}}) for a detailed treatment of this pattern.
+
+**CI for ephemeral validation**:
+A GitHub Actions workflow that clones, installs, and runs `make test` on every push.
+This catches environment drift automatically.
+
+**Modularity via subdatasets**:
+The raw data could live in its own DataLad subdataset, independently versioned and reusable.
+A colleague running a different analysis on the same stars would `datalad install` the data module rather than re-fetching from the API.
+
+**Reproducible re-execution**:
+`datalad rerun` replays the recorded provenance.
+If the raw data is updated (say, a new Gaia release), update the input, `datalad rerun`, and the outputs reflect the new data.
+Branches can separate outputs produced from different input versions.
+
+**Archival distribution**:
+Deposit the repository on [Zenodo](https://zenodo.org/) for a DOI.
+Push the container image to a registry.
+Mirror data to multiple remotes so no single point of failure breaks reproducibility.

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -348,7 +348,7 @@ This is the [ephemeral shell reproducer]({{< ref "examples/ephemeral-shell-repro
 
 ### 10. Push to GitHub
 
-We push to a public repository.
+We push to a [public repository](https://github.com/asmacdo/STAMPED-stellar-distances).
 Now anyone can `git clone`, `pip install -r requirements.txt`, `make`, and reproduce the result.
 
 Until this step the research object was self-contained and reproducible — but only on our machine.

--- a/content/examples/stellar-distance-walkthrough.steps.json
+++ b/content/examples/stellar-distance-walkthrough.steps.json
@@ -1,0 +1,11 @@
+[
+  "Initial analysis: compute stellar distances",
+  "Split into fetch and compute scripts",
+  "Organize into code/, raw/, output/",
+  "Compute distances for 100 nearest stars",
+  "Add README with reproduction instructions",
+  "Add Makefile encoding the full pipeline",
+  "Add verification test against Gaia GSP-Phot reference distances",
+  "Rewrite fetch with requests, declare and pin dependencies",
+  "Add ephemeral reproduction script"
+]

--- a/layouts/_default/_markup/render-codeblock-sh.html
+++ b/layouts/_default/_markup/render-codeblock-sh.html
@@ -7,6 +7,7 @@
 {{- $filtered := slice -}}
 {{- $testrunID := "" -}}
 {{- $materializeList := slice -}}
+{{- $isHidden := false -}}
 {{- range split $raw "\n" -}}
   {{- if findRE `^\s*#\s*pragma:` . -}}
     {{- /* Extract testrun and materialize values before stripping */ -}}
@@ -18,14 +19,20 @@
       {{- $repo := replaceRE `^#\s*pragma:\s*materialize\s+` "" $trimmed -}}
       {{- $materializeList = $materializeList | append $repo -}}
     {{- end -}}
+    {{- if findRE `^#\s*pragma:\s*render\s+hidden` $trimmed -}}
+      {{- $isHidden = true -}}
+    {{- end -}}
   {{- else -}}
     {{- $filtered = $filtered | append . -}}
   {{- end -}}
 {{- end -}}
+{{- if and $isHidden (not (getenv "HUGO_SHOW_HIDDEN")) -}}
+  {{- /* Hidden block: no HTML output */ -}}
+{{- else -}}
 {{- $code := delimit $filtered "\n" -}}
 {{- $isScript := hasPrefix $code "#!" -}}
-{{- $class := cond $isScript "codeblock-script" "codeblock-snippet" -}}
-{{- $label := cond $isScript "script" "snippet" -}}
+{{- $class := cond $isHidden "codeblock-hidden" (cond $isScript "codeblock-script" "codeblock-snippet") -}}
+{{- $label := cond $isHidden "hidden" (cond $isScript "script" "snippet") -}}
 <div class="codeblock-wrapper {{ $class }}">
   <span class="codeblock-label">{{ $label }}</span>
   {{- highlight $code .Type .Options -}}
@@ -39,4 +46,5 @@
       <a href="{{ $repoURL }}/tree/examples/{{ $fileStem }}/{{ $testrunID }}/{{ $repo }}">Browse <code>{{ $repo }}</code></a>
     {{- end -}}
   </div>
+{{- end -}}
 {{- end -}}

--- a/layouts/_default/_markup/render-codeblock-sh.html
+++ b/layouts/_default/_markup/render-codeblock-sh.html
@@ -1,5 +1,5 @@
 {{- /* render-codeblock-sh: handles ```sh blocks.
-     - Strips lines matching "# pragma:" before rendering.
+     - Strips lines matching "# pragma:" and "# snippet:" / "# /snippet" before rendering.
      - Detects shebang (#!) → "script" label; otherwise → "snippet" label.
      - If "# pragma: materialize" is present, emits browse-example links.
 */ -}}
@@ -9,7 +9,7 @@
 {{- $materializeList := slice -}}
 {{- $isHidden := false -}}
 {{- range split $raw "\n" -}}
-  {{- if findRE `^\s*#\s*pragma:` . -}}
+  {{- if or (findRE `^\s*#\s*pragma:` .) (findRE `^\s*#\s*snippet:` .) (findRE `^\s*#\s*/snippet` .) -}}
     {{- /* Extract testrun and materialize values before stripping */ -}}
     {{- $trimmed := trim . " " -}}
     {{- if findRE `^#\s*pragma:\s*testrun\s+` $trimmed -}}

--- a/layouts/shortcodes/snippet.html
+++ b/layouts/shortcodes/snippet.html
@@ -1,0 +1,87 @@
+{{- /* snippet: extract a named code region from a build script on this page.
+     Finds "# snippet: <id>" / "# /snippet" markers, extracts heredoc body.
+     Params: id (required), lang (default "text"), lines (e.g. "3-6,10-12"). */ -}}
+
+{{- $id := .Get "id" -}}
+{{- $lang := .Get "lang" | default "text" -}}
+{{- $linesParam := .Get "lines" | default "" -}}
+
+{{- /* Phase 1: Find snippet region by scanning page raw content */ -}}
+{{- $raw := .Page.RawContent -}}
+{{- $allLines := split $raw "\n" -}}
+{{- $inSnippet := false -}}
+{{- $snippetLines := slice -}}
+{{- range $allLines -}}
+  {{- $trimmed := trim . " \t" -}}
+  {{- if not $inSnippet -}}
+    {{- if eq $trimmed (printf "# snippet: %s" $id) -}}
+      {{- $inSnippet = true -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if eq $trimmed "# /snippet" -}}
+      {{- $inSnippet = false -}}
+    {{- else -}}
+      {{- $snippetLines = $snippetLines | append . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Phase 2: Extract heredoc body if present */ -}}
+{{- $heredocLines := slice -}}
+{{- $inHeredoc := false -}}
+{{- $heredocDelim := "" -}}
+{{- range $snippetLines -}}
+  {{- if not $inHeredoc -}}
+    {{- if findRE `<<'[A-Za-z_]+'` . -}}
+      {{- $heredocDelim = replaceRE `.*<<'([A-Za-z_]+)'.*` "$1" . -}}
+      {{- $inHeredoc = true -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if eq (trim . " \t") $heredocDelim -}}
+      {{- $inHeredoc = false -}}
+    {{- else -}}
+      {{- $heredocLines = $heredocLines | append . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Use heredoc body if found, otherwise raw snippet lines */ -}}
+{{- $content := $snippetLines -}}
+{{- if gt (len $heredocLines) 0 -}}
+  {{- $content = $heredocLines -}}
+{{- end -}}
+
+{{- /* Phase 3: Line selection */ -}}
+{{- if ne $linesParam "" -}}
+  {{- $selected := slice -}}
+  {{- $prevEnd := 0 -}}
+  {{- $ranges := split $linesParam "," -}}
+  {{- range $ranges -}}
+    {{- $r := trim . " " -}}
+    {{- $parts := split $r "-" -}}
+    {{- $start := int (index $parts 0) -}}
+    {{- $end := $start -}}
+    {{- if gt (len $parts) 1 -}}
+      {{- $end = int (index $parts 1) -}}
+    {{- end -}}
+    {{- /* Insert ... between non-contiguous ranges */ -}}
+    {{- if and (gt $prevEnd 0) (gt $start (add $prevEnd 1)) -}}
+      {{- $selected = $selected | append "..." -}}
+    {{- end -}}
+    {{- range seq $start $end -}}
+      {{- $idx := sub . 1 -}}
+      {{- if and (ge $idx 0) (lt $idx (len $content)) -}}
+        {{- $selected = $selected | append (index $content $idx) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $prevEnd = $end -}}
+  {{- end -}}
+  {{- $content = $selected -}}
+{{- end -}}
+
+{{- /* Render */ -}}
+{{- $code := delimit $content "\n" -}}
+<div class="codeblock-wrapper codeblock-snippet">
+  <span class="codeblock-label">snippet</span>
+  {{- highlight $code $lang "" -}}
+</div>

--- a/layouts/shortcodes/step-link.html
+++ b/layouts/shortcodes/step-link.html
@@ -1,7 +1,13 @@
-{{- /* step-link: render a link to a materialized example branch at a given tag.
-     Derives repo URL from site.Params.article.editurl.
-     Params: tag (required), text (optional, default "Full project at this step"). */ -}}
-{{- $tag := .Get "tag" -}}
+{{- /* step-link: render a link to a materialized example at a given step.
+     Looks up the commit SHA from a Hugo data file (data/<stem>.json)
+     written by materialize_examples.
+     Params: step (required), text (optional, default "Full project at this step").
+     Page param: materialize_stem (set in front matter, used as data file key). */ -}}
+{{- $step := .Get "step" -}}
 {{- $text := .Get "text" | default "Full project at this step" -}}
+{{- $stem := .Page.Params.materialize_stem -}}
+{{- $data := index site.Data $stem -}}
+{{- $tag := printf "step-%s" $step -}}
+{{- $sha := index $data $tag -}}
 {{- $repoURL := replaceRE `/tree/.*$` "" site.Params.article.editurl -}}
-<a href="{{ $repoURL }}/tree/{{ $tag }}">{{ $text }}</a>
+<a href="{{ $repoURL }}/tree/{{ $sha }}">{{ $text }}</a>

--- a/layouts/shortcodes/step-link.html
+++ b/layouts/shortcodes/step-link.html
@@ -1,0 +1,7 @@
+{{- /* step-link: render a link to a materialized example branch at a given tag.
+     Derives repo URL from site.Params.article.editurl.
+     Params: tag (required), text (optional, default "Full project at this step"). */ -}}
+{{- $tag := .Get "tag" -}}
+{{- $text := .Get "text" | default "Full project at this step" -}}
+{{- $repoURL := replaceRE `/tree/.*$` "" site.Params.article.editurl -}}
+<a href="{{ $repoURL }}/tree/{{ $tag }}">{{ $text }}</a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.pytest.ini_options]
 addopts = "-p no:doctest"
+
+[tool.codespell]
+ignore-words-list = "prevEnd"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,5 @@
 sybil>=9.0
 pytest>=7.0
+datalad
+pip-tools
+requests

--- a/scripts/materialize_examples
+++ b/scripts/materialize_examples
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -38,6 +39,7 @@ from snippet_parser import ScriptBlock, iter_script_blocks
 FIXED_EPOCH = "2000-01-01T00:00:00+00:00"
 
 CONTENT_DIR = Path("content/examples")
+DATA_DIR = Path("data")
 
 # Custom notes ref to avoid colliding with default refs/notes/commits.
 NOTES_REF = "refs/notes/materialize"
@@ -196,6 +198,25 @@ def rewrite_submodule_urls(
 # Local branch creation
 # ---------------------------------------------------------------------------
 
+def _resolve_steps(repo_dir: Path) -> dict[str, str]:
+    """Return a ``{"step-1": sha, "step-2": sha, ...}`` mapping.
+
+    Each commit in the repo's history (oldest first) becomes a step.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "log", "--reverse", "--format=%H"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    steps = {}
+    for i, sha in enumerate(result.stdout.splitlines(), 1):
+        sha = sha.strip()
+        if sha:
+            steps[f"step-{i}"] = sha
+    return steps
+
+
 def import_as_local_branch(repo_dir: Path, target_branch: str) -> None:
     """Fetch *repo_dir*'s HEAD into a local branch in the current repo."""
     toplevel = repo_toplevel()
@@ -205,12 +226,6 @@ def import_as_local_branch(repo_dir: Path, target_branch: str) -> None:
             str(repo_dir),
             f"+HEAD:refs/heads/{target_branch}",
         ],
-        check=True,
-        cwd=str(toplevel),
-    )
-    # Also import any tags from the example repo.
-    subprocess.run(
-        ["git", "fetch", str(repo_dir), "+refs/tags/*:refs/tags/*"],
         check=True,
         cwd=str(toplevel),
     )
@@ -250,9 +265,8 @@ def push_branches_and_notes(remote: str) -> None:
 
     # Build refspecs
     refspecs = [f"refs/heads/{b}:refs/heads/{b}" for b in branches]
-    # Also push notes and tags
+    # Also push notes
     refspecs.append(f"{NOTES_REF}:{NOTES_REF}")
-    refspecs.append("+refs/tags/*:refs/tags/*")
 
     print(f"Pushing {len(branches)} branch(es) + notes to {remote}…")
     subprocess.run(
@@ -401,13 +415,27 @@ def process_block(
                     repo_dir, block.file_stem, testrun_id, remote_url,
                 )
 
+            # Map commits (by position) to step names.
+            step_shas = _resolve_steps(repo_dir)
+
             if dry_run:
                 print(f"  dry-run: would create branch {bname}")
+                if step_shas:
+                    print(f"  dry-run: would write step data for {list(step_shas)}")
             elif worktrees_under:
                 create_worktree(repo_dir, bname, worktrees_under)
             else:
                 import_as_local_branch(repo_dir, bname)
                 store_hash_note(bname, hash_val)
+
+            # Write step→SHA mapping as a Hugo data file.
+            if step_shas and not dry_run:
+                DATA_DIR.mkdir(exist_ok=True)
+                data_file = DATA_DIR / f"{block.file_stem}.json"
+                data_file.write_text(
+                    json.dumps(step_shas, indent=2, sort_keys=True) + "\n",
+                )
+                print(f"  data → {data_file}")
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/scripts/materialize_examples
+++ b/scripts/materialize_examples
@@ -208,6 +208,12 @@ def import_as_local_branch(repo_dir: Path, target_branch: str) -> None:
         check=True,
         cwd=str(toplevel),
     )
+    # Also import any tags from the example repo.
+    subprocess.run(
+        ["git", "fetch", str(repo_dir), "+refs/tags/*:refs/tags/*"],
+        check=True,
+        cwd=str(toplevel),
+    )
     print(f"  branch → {target_branch}")
 
 
@@ -244,8 +250,9 @@ def push_branches_and_notes(remote: str) -> None:
 
     # Build refspecs
     refspecs = [f"refs/heads/{b}:refs/heads/{b}" for b in branches]
-    # Also push notes
+    # Also push notes and tags
     refspecs.append(f"{NOTES_REF}:{NOTES_REF}")
+    refspecs.append("+refs/tags/*:refs/tags/*")
 
     print(f"Pushing {len(branches)} branch(es) + notes to {remote}…")
     subprocess.run(

--- a/scripts/materialize_examples
+++ b/scripts/materialize_examples
@@ -44,6 +44,11 @@ DATA_DIR = Path("data")
 # Custom notes ref to avoid colliding with default refs/notes/commits.
 NOTES_REF = "refs/notes/materialize"
 
+# Notes ref carrying the per-branch step→sha JSON map consumed by the
+# step-link Hugo shortcode.  Sibling to NOTES_REF so we can extend the
+# materialization cache without re-running the build script at deploy time.
+STEP_MAP_NOTES_REF = "refs/notes/materialize-step-map"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -135,6 +140,31 @@ def store_hash_note(target_branch: str, hash_val: str) -> None:
         [
             "git", "notes", f"--ref={NOTES_REF}",
             "add", "-f", "-m", f"Script-Hash: {hash_val}",
+            commit,
+        ],
+        check=True,
+    )
+
+
+def store_step_map_note(target_branch: str, step_shas: dict[str, str]) -> None:
+    """Attach the resolved step-map JSON as a note on *target_branch*'s tip.
+
+    Deploy workflows fetch ``STEP_MAP_NOTES_REF`` and use the
+    ``--export-data-from-notes`` mode to materialize ``data/<stem>.json``
+    without re-running the build script.
+    """
+    tip = subprocess.run(
+        ["git", "rev-parse", f"refs/heads/{target_branch}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commit = tip.stdout.strip()
+    payload = json.dumps(step_shas, indent=2, sort_keys=True) + "\n"
+    subprocess.run(
+        [
+            "git", "notes", f"--ref={STEP_MAP_NOTES_REF}",
+            "add", "-f", "-m", payload,
             commit,
         ],
         check=True,
@@ -278,6 +308,51 @@ def create_worktree(
 # Push
 # ---------------------------------------------------------------------------
 
+def export_data_from_notes() -> None:
+    """Write ``data/<stem>.json`` for every example branch with a step-map note.
+
+    Used by deploy workflows: after fetching the example branches and the
+    ``STEP_MAP_NOTES_REF`` notes ref from origin, this command extracts
+    the cached step maps into ``data/`` for Hugo to consume — no script
+    re-execution, no external dependencies.
+    """
+    result = subprocess.run(
+        ["git", "branch", "--list", "examples/*", "--format=%(refname:short)"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    branches = [b.strip() for b in result.stdout.splitlines() if b.strip()]
+    if not branches:
+        print("No example branches found.")
+        return
+
+    DATA_DIR.mkdir(exist_ok=True)
+    wrote_any = False
+    for branch in branches:
+        # examples/<stem>/<testrun>/<repo>
+        parts = branch.split("/")
+        if len(parts) < 4:
+            continue
+        stem = parts[1]
+        tip = subprocess.run(
+            ["git", "rev-parse", branch],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        note = subprocess.run(
+            ["git", "notes", f"--ref={STEP_MAP_NOTES_REF}", "show", tip],
+            capture_output=True, text=True,
+        )
+        if note.returncode != 0:
+            continue
+        data_file = DATA_DIR / f"{stem}.json"
+        data_file.write_text(note.stdout)
+        print(f"  {branch} → {data_file}")
+        wrote_any = True
+    if not wrote_any:
+        print("No step-map notes found on local example branches.")
+
+
 def push_branches_and_notes(remote: str) -> None:
     """Push all ``examples/*`` branches and materialize notes to *remote*."""
     # Gather local example branches
@@ -293,8 +368,9 @@ def push_branches_and_notes(remote: str) -> None:
 
     # Build refspecs
     refspecs = [f"refs/heads/{b}:refs/heads/{b}" for b in branches]
-    # Also push notes
+    # Also push notes (script-hash cache + step-map for deploys)
     refspecs.append(f"{NOTES_REF}:{NOTES_REF}")
+    refspecs.append(f"{STEP_MAP_NOTES_REF}:{STEP_MAP_NOTES_REF}")
 
     print(f"Pushing {len(branches)} branch(es) + notes to {remote}…")
     subprocess.run(
@@ -414,6 +490,10 @@ def process_block(
                 break
         if all_cached:
             print(f"  cache hit (hash {hash_val[:12]}…) — skipping")
+            # Known wart: this path does not refresh the step-map note or
+            # data/<stem>.json.  If declared_steps changes without the
+            # script changing, the cached note can go stale.  To force a
+            # rebuild: `git notes --ref=materialize remove <branch-tip>`.
             return
 
     print(f"  hash {hash_val[:12]}… — executing script")
@@ -457,14 +537,17 @@ def process_block(
                 import_as_local_branch(repo_dir, bname)
                 store_hash_note(bname, hash_val)
 
-            # Write step→SHA mapping as a Hugo data file.
-            if step_shas and not dry_run:
+            # Write step→SHA mapping as a Hugo data file, and persist it
+            # as a git note so deploy workflows can recover it without
+            # re-running the build script.
+            if step_shas and not dry_run and not worktrees_under:
                 DATA_DIR.mkdir(exist_ok=True)
                 data_file = DATA_DIR / f"{block.file_stem}.json"
                 data_file.write_text(
                     json.dumps(step_shas, indent=2, sort_keys=True) + "\n",
                 )
                 print(f"  data → {data_file}")
+                store_step_map_note(bname, step_shas)
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -501,7 +584,20 @@ def main(argv: list[str] | None = None) -> None:
         metavar="PATH",
         help="Create directory copies instead of local branches.",
     )
+    parser.add_argument(
+        "--export-data-from-notes",
+        action="store_true",
+        help=(
+            "Skip script execution.  Read step-map notes from local "
+            "example branches and write data/<stem>.json files (for "
+            "Hugo deploys)."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    if args.export_data_from_notes:
+        export_data_from_notes()
+        return
 
     if not CONTENT_DIR.is_dir():
         print(f"ERROR: {CONTENT_DIR} not found", file=sys.stderr)

--- a/scripts/materialize_examples
+++ b/scripts/materialize_examples
@@ -198,23 +198,51 @@ def rewrite_submodule_urls(
 # Local branch creation
 # ---------------------------------------------------------------------------
 
-def _resolve_steps(repo_dir: Path) -> dict[str, str]:
-    """Return a ``{"step-1": sha, "step-2": sha, ...}`` mapping.
+def _resolve_steps(
+    repo_dir: Path,
+    declared_steps: list[str] | None,
+) -> dict[str, str]:
+    """Map declared step subjects to commit SHAs.
 
-    Each commit in the repo's history (oldest first) becomes a step.
+    *declared_steps* is the ordered list of commit-subject substrings from
+    the walkthrough's front matter (``params.steps``).  Each entry is
+    matched against the next-following commit (oldest-first) whose subject
+    contains it.  Out-of-order or unmatched entries raise.
+
+    Returns ``{}`` when no steps are declared — the data file is only
+    used by examples that opt in via the step-link shortcode.
     """
+    if not declared_steps:
+        return {}
+
     result = subprocess.run(
-        ["git", "-C", str(repo_dir), "log", "--reverse", "--format=%H"],
+        ["git", "-C", str(repo_dir), "log", "--reverse", "--format=%H %s"],
         capture_output=True,
         text=True,
         check=True,
     )
-    steps = {}
-    for i, sha in enumerate(result.stdout.splitlines(), 1):
-        sha = sha.strip()
-        if sha:
-            steps[f"step-{i}"] = sha
-    return steps
+    commits = [
+        line.split(" ", 1)
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+
+    mapping: dict[str, str] = {}
+    cursor = 0
+    for i, needle in enumerate(declared_steps, 1):
+        found = next(
+            (j for j in range(cursor, len(commits)) if needle in commits[j][1]),
+            None,
+        )
+        if found is None:
+            remaining = [c[1] for c in commits[cursor:]]
+            raise RuntimeError(
+                f"step-{i}: no commit subject contains {needle!r}.  "
+                f"Remaining commit subjects: {remaining}"
+            )
+        mapping[f"step-{i}"] = commits[found][0]
+        cursor = found + 1
+    return mapping
 
 
 def import_as_local_branch(repo_dir: Path, target_branch: str) -> None:
@@ -361,6 +389,7 @@ def process_block(
     dry_run: bool,
     strict: bool,
     worktrees_under: Path | None,
+    declared_steps: list[str] | None,
 ) -> None:
     """Process a single script block: execute, capture, import as branch."""
     testrun_id = str(block.pragmas.get("testrun", "unnamed"))
@@ -415,8 +444,8 @@ def process_block(
                     repo_dir, block.file_stem, testrun_id, remote_url,
                 )
 
-            # Map commits (by position) to step names.
-            step_shas = _resolve_steps(repo_dir)
+            # Map declared step subjects to commit SHAs.
+            step_shas = _resolve_steps(repo_dir, declared_steps)
 
             if dry_run:
                 print(f"  dry-run: would create branch {bname}")
@@ -490,6 +519,14 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     for md_path in md_files:
+        # Sidecar JSON file (e.g. foo.md → foo.steps.json) declares the
+        # ordered commit-subject substrings used by the step-link shortcode.
+        steps_path = md_path.with_suffix(".steps.json")
+        declared_steps = (
+            json.loads(steps_path.read_text(encoding="utf-8"))
+            if steps_path.exists()
+            else None
+        )
         for block in iter_script_blocks(md_path):
             materialize_list = block.pragmas.get("materialize", [])
             if not materialize_list:
@@ -500,6 +537,7 @@ def main(argv: list[str] | None = None) -> None:
                 dry_run=args.dry_run,
                 strict=args.strict,
                 worktrees_under=args.worktrees_under,
+                declared_steps=declared_steps,
             )
 
     if args.push and not args.dry_run:

--- a/scripts/snippet_parser.py
+++ b/scripts/snippet_parser.py
@@ -50,17 +50,53 @@ class ScriptBlock(NamedTuple):
     file_stem: str
 
 
+def _merge_pragmas(
+    target: dict[str, str | list[str]],
+    source: dict[str, str | list[str]],
+) -> None:
+    """Merge *source* pragmas into *target* (first-wins for scalars)."""
+    for k, v in source.items():
+        if k == "materialize":
+            target.setdefault("materialize", [])
+            assert isinstance(target["materialize"], list)
+            assert isinstance(v, list)
+            target["materialize"].extend(v)
+        elif k not in target:
+            target[k] = v
+
+
 def iter_script_blocks(md_path: str | Path) -> Iterator[ScriptBlock]:
     """Yield :class:`ScriptBlock` instances from a Markdown file.
 
     Only blocks containing ``# pragma: testrun`` are yielded.
+
+    When multiple blocks share the same ``testrun`` identifier they are
+    concatenated (in document order) into a single :class:`ScriptBlock`.
+    Scalar pragmas use first-wins semantics; ``materialize`` lists are
+    concatenated.
     """
     md_path = Path(md_path)
     text = md_path.read_text(encoding="utf-8")
     file_stem = md_path.stem
+
+    groups: dict[str, dict] = {}  # testrun_id -> {"codes": [...], "pragmas": {...}}
+    order: list[str] = []
+
     for m in FENCE_RE.finditer(text):
         code = m.group(1)
         if "# pragma: testrun" not in code:
             continue
         pragmas = parse_pragmas(code)
-        yield ScriptBlock(code=code, pragmas=pragmas, file_stem=file_stem)
+        testrun_id = pragmas.get("testrun", "")
+
+        if testrun_id not in groups:
+            groups[testrun_id] = {"codes": [], "pragmas": {}}
+            order.append(testrun_id)
+
+        groups[testrun_id]["codes"].append(code)
+        _merge_pragmas(groups[testrun_id]["pragmas"], pragmas)
+
+    for testrun_id in order:
+        group = groups[testrun_id]
+        combined = "\n".join(group["codes"])
+        yield ScriptBlock(code=combined, pragmas=group["pragmas"], file_stem=file_stem)

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -92,6 +92,19 @@ class TestParsePragmas:
         result = parse_pragmas(code)
         assert result["testrun"] == ""
 
+    def test_render_hidden_pragma(self):
+        code = textwrap.dedent("""\
+            #!/bin/sh
+            # pragma: testrun full-build
+            # pragma: render hidden
+            # pragma: materialize stellar-distance
+            echo hello
+        """)
+        result = parse_pragmas(code)
+        assert result["render"] == "hidden"
+        assert result["testrun"] == "full-build"
+        assert result["materialize"] == ["stellar-distance"]
+
 
 class TestFenceRe:
     def test_matches_sh_block(self):
@@ -139,6 +152,84 @@ class TestIterScriptBlocks:
         md.write_text("```sh\n# pragma: testrun s1\necho hi\n```\n")
         blocks = list(iter_script_blocks(md))
         assert blocks[0].file_stem == "stamped-awk-evolution"
+
+    def test_multi_block_same_testrun(self, tmp_path):
+        """Multiple blocks sharing a testrun ID are concatenated."""
+        md = tmp_path / "example.md"
+        md.write_text(textwrap.dedent("""\
+            # Step 1
+
+            ```sh
+            #!/bin/sh
+            # pragma: testrun demo-1
+            # pragma: requires sh git
+            # pragma: materialize myrepo
+            set -eu
+            echo step1
+            ```
+
+            Some narrative text.
+
+            ```sh
+            # pragma: testrun demo-1
+            echo step2
+            ```
+
+            More narrative.
+
+            ```sh
+            # pragma: testrun demo-1
+            echo step3
+            ```
+        """))
+        blocks = list(iter_script_blocks(md))
+        assert len(blocks) == 1
+        assert "echo step1" in blocks[0].code
+        assert "echo step2" in blocks[0].code
+        assert "echo step3" in blocks[0].code
+        # First-wins for scalar pragmas
+        assert blocks[0].pragmas["testrun"] == "demo-1"
+        assert blocks[0].pragmas["requires"] == "sh git"
+        assert blocks[0].pragmas["materialize"] == ["myrepo"]
+
+    def test_multi_block_different_testruns(self, tmp_path):
+        """Blocks with different testrun IDs remain separate."""
+        md = tmp_path / "example.md"
+        md.write_text(textwrap.dedent("""\
+            ```sh
+            # pragma: testrun s1
+            echo one
+            ```
+
+            ```sh
+            # pragma: testrun s2
+            echo two
+            ```
+        """))
+        blocks = list(iter_script_blocks(md))
+        assert len(blocks) == 2
+        assert blocks[0].pragmas["testrun"] == "s1"
+        assert blocks[1].pragmas["testrun"] == "s2"
+
+    def test_multi_block_pragma_first_wins(self, tmp_path):
+        """First block's scalar pragmas take precedence."""
+        md = tmp_path / "example.md"
+        md.write_text(textwrap.dedent("""\
+            ```sh
+            # pragma: testrun demo-1
+            # pragma: timeout 600
+            echo first
+            ```
+
+            ```sh
+            # pragma: testrun demo-1
+            # pragma: timeout 30
+            echo second
+            ```
+        """))
+        blocks = list(iter_script_blocks(md))
+        assert len(blocks) == 1
+        assert blocks[0].pragmas["timeout"] == "600"
 
 
 # ---------------------------------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = snippets,hugo
 [testenv:snippets]
 skip_install = true
 deps = -r requirements-test.txt
-commands = pytest content/ -v {posargs}
+# datalad is needed at runtime but its pytest plugin breaks sybil collection
+commands = pytest content/ -v -p no:datalad {posargs}
 
 [testenv:hugo]
 skip_install = true


### PR DESCRIPTION
Issues:
 - Closes https://github.com/myyoda/principles-paper/issues/79

## Summary

Walkthrough that incrementally builds a STAMPED research object from a single Python script to a fully reproducible, tracked, distributable pipeline — computing stellar distances from Gaia DR3 parallax data.

Organized by real workflow problems ("which version of the data did I use?", "why doesn't this run on my colleague's laptop?"), not by STAMPED acronym order. Each step solves a concrete failure mode and notes which properties it advances.

**Update April 2**: Major restructuring: the walkthrough now embeds a build script that is the single source of truth. The materialization system executes it to produce the example repo as a branch. Abbreviated code snippets in the prose are extracted from the build script via a new `snippet` shortcode.

Each step links to the [full project state](https://github.com/myyoda/principles-examples/tree/stellar-step-1) via `stellar-step-{N}` tags created during materialization.

## TODOs

- [x] Review whether `fair_principles: ["R", "A"]` is right or if "I" (interoperable — CSV + standard tools) also applies
- [x] Check Netlify preview renders correctly