### PR TITLE
Tag awk-evolution example as introduction

### DIFF
--- a/content/examples/stamped-awk-evolution.md
+++ b/content/examples/stamped-awk-evolution.md
@@ -3,7 +3,7 @@ title: "From Script to STAMPED Research Object"
 date: 2026-02-20
 description: "Progressive evolution of a simple data analysis from throwaway script to fully STAMPED research object"
 summary: "Four scenarios showing how to incrementally add STAMPED properties to a shell-based analysis using git, make, and singularity."
-tags: ["shell", "posix", "awk", "make", "git", "singularity", "containers"]
+tags: ["introduction", "shell", "posix", "awk", "make", "git", "singularity", "containers"]
 stamped_principles: ["S", "T", "A", "M", "P", "E", "D"]
 fair_principles: ["R", "A"]
 instrumentation_levels: ["pattern"]

--- a/content/examples/stamped-awk-evolution.md
+++ b/content/examples/stamped-awk-evolution.md
@@ -3,7 +3,7 @@ title: "From Script to STAMPED Research Object"
 date: 2026-02-20
 description: "Progressive evolution of a simple data analysis from throwaway script to fully STAMPED research object"
 summary: "Four scenarios showing how to incrementally add STAMPED properties to a shell-based analysis using git, make, and singularity."
-tags: ["introduction", "shell", "posix", "awk", "make", "git", "singularity", "containers"]
+tags: ["STAMPED-intro", "shell", "POSIX", "awk", "make", "git", "singularity", "containers"]
 stamped_principles: ["S", "T", "A", "M", "P", "E", "D"]
 fair_principles: ["R", "A"]
 instrumentation_levels: ["pattern"]


### PR DESCRIPTION
Adds an "introduction" tag to the awk-evolution example so the principles paper's examples section can link to a curated entry-point subset via /tags/introduction/. Only stamped-awk-evolution for now, it is the one example that tours all seven STAMPED properties progressively over a single trivial task, which is what the paper section needs. Stellar evolution should also have this tag when that merges