### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/content/examples/datasette-mvc-actionable.md
+++ b/content/examples/datasette-mvc-actionable.md
@@ -40,7 +40,7 @@ the data, the dataset is not actionable -- it is passive.
 SQLite database file and serves it as an interactive web application.
 With a single command, it provides:
 
-- A **browseable web UI** for every table, with sorting, filtering, and
+- A **browsable web UI** for every table, with sorting, filtering, and
   full-text search.
 - A **SQL query interface** where users can write and share arbitrary
   queries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,9 @@
 [tool.pytest.ini_options]
 addopts = "-p no:doctest"
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,venv,.venv,.tox,package-lock.json,i18n,*.lock,*.css,*.min.*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ addopts = "-p no:doctest"
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,venv,.venv,.tox,package-lock.json,i18n,*.lock,*.css,*.min.*'
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,venv,.venv,.tox,package-lock.json,i18n,*.lock,*.css,*.min.*,.npm,.cache,.pytest_cache,node_modules,themes,public,resources,stamped-examples.md,.git-meta'
 check-hidden = true
 # ignore-regex = ''
 # ignore-words-list = ''


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly with a positive feedback (see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

CI workflow has `permissions` set only to `read` so also should be safe.

## Changes

### Configuration & Infrastructure
- Added `[tool.codespell]` section to `pyproject.toml`
- Created `.github/workflows/codespell.yml` to check spelling on push and PRs (read-only permissions)

### Skip Patterns
The skip list was tuned to avoid drowning in false positives from local build artifacts and vendored content:
- `.npm`, `.cache`, `.pytest_cache`, `node_modules` — local caches
- `themes` — Congo theme submodule (vendored, upstream's responsibility)
- `public`, `resources` — Hugo build output
- `stamped-examples.md` — generated PDF source aggregate
- `.git-meta` — local Claude Code working area
- standard skips for `.pdf`, `.svg`, `.css`, `.min.*`, `i18n`, lockfiles, virtualenvs

### Typo Fixes

Non-ambiguous typo fixed:
- `browseable` → `browsable` in `content/examples/datasette-mvc-actionable.md`

## Testing

✅ `uvx codespell` passes with zero errors after all changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
