### PR TITLE
docs: add commit co-authorship rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,15 @@ CI runs this on push to main with `--strict --push`.
 - Four custom taxonomies: `stamped_principles`, `fair_principles`, `instrumentation_levels`, `aspirations`
 - State banners for `wip` / `uncurated-ai` content
 - Code block renderers distinguish scripts (full shebang) from snippets
+
+## Commit co-authorship
+
+Every commit you author MUST include a `Co-Authored-By` trailer identifying both your tool name + version and your underlying model + version. Format:
+
+```
+Co-Authored-By: <Tool> <tool-version> / <Model> <model-version> <noreply@<vendor-domain>>
+```
+
+Use the actual versions reported by your tool. Don't guess.
+
+(Convention adopted from https://github.com/con/catenate `conboarding.md` § Commit Co-Authorship.)


### PR DESCRIPTION
Adopts the convention from [con/catenate#30](https://github.com/con/catenate/pull/30): AI-authored commits MUST carry a `Co-Authored-By` trailer identifying tool + version and model + version, so the public git history is the inspectable provenance record (per the STAMPED manuscript's Acknowledgments).