### PR TITLE
Grant Test workflow contents:write for materialize push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Configure git
         run: |


### PR DESCRIPTION
The materialize step pushes example branches and notes refs to origin on push to main. Without an explicit permissions block, GITHUB_TOKEN falls back to the repo default (read-only) and the push fails with 403.

This test was already failing on merge failing prior to [stellar-distance-example](https://github.com/stamped-principles/stamped-examples/pull/16) , but that PR added a dependency for hugo.yml to only run after materialization (test.yml) succeeded.