### PR TITLE
Rename STAMPED principles to noun forms site-wide

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -19,13 +19,13 @@ treatment; the table below is a quick reference:
 
 | Property | Core idea |
 |---|---|
-| **[S]({{< ref "stamped_principles/s" >}})** -- [Self-contained]({{< ref "stamped_principles/s" >}}) | Everything needed to replicate results is within a single top-level boundary -- the "don't look up" rule. |
-| **[T]({{< ref "stamped_principles/t" >}})** -- [Tracked]({{< ref "stamped_principles/t" >}}) | All components are content-addressed and version-controlled; provenance of every modification is recorded. |
-| **[A]({{< ref "stamped_principles/a" >}})** -- [Actionable]({{< ref "stamped_principles/a" >}}) | Procedures are executable specifications, not just documentation -- a cross-cutting property that applies to every other STAMPED dimension. |
-| **[M]({{< ref "stamped_principles/m" >}})** -- [Modular]({{< ref "stamped_principles/m" >}}) | Components are organized as independently versioned modules that can be composed, updated, and reused separately. |
-| **[P]({{< ref "stamped_principles/p" >}})** -- [Portable]({{< ref "stamped_principles/p" >}}) | Procedures do not depend on undocumented host state; computational environments are explicitly specified and versioned. |
-| **[E]({{< ref "stamped_principles/e" >}})** -- [Ephemeral]({{< ref "stamped_principles/e" >}}) | Results can be produced in temporary, disposable environments built solely from the research object's contents -- validating that other properties hold. |
-| **[D]({{< ref "stamped_principles/d" >}})** -- [Distributable]({{< ref "stamped_principles/d" >}}) | The research object and all its components are persistently retrievable by others, packaged like a software distribution. |
+| **[S]({{< ref "stamped_principles/s" >}})** -- [Self-containment]({{< ref "stamped_principles/s" >}}) | Everything needed to replicate results is within a single top-level boundary -- the "don't look up" rule. |
+| **[T]({{< ref "stamped_principles/t" >}})** -- [Tracking]({{< ref "stamped_principles/t" >}}) | All components are content-addressed and version-controlled; provenance of every modification is recorded. |
+| **[A]({{< ref "stamped_principles/a" >}})** -- [Actionability]({{< ref "stamped_principles/a" >}}) | Procedures are executable specifications, not just documentation -- a cross-cutting property that applies to every other STAMPED dimension. |
+| **[M]({{< ref "stamped_principles/m" >}})** -- [Modularity]({{< ref "stamped_principles/m" >}}) | Components are organized as independently versioned modules that can be composed, updated, and reused separately. |
+| **[P]({{< ref "stamped_principles/p" >}})** -- [Portability]({{< ref "stamped_principles/p" >}}) | Procedures do not depend on undocumented host state; computational environments are explicitly specified and versioned. |
+| **[E]({{< ref "stamped_principles/e" >}})** -- [Ephemerality]({{< ref "stamped_principles/e" >}}) | Results can be produced in temporary, disposable environments built solely from the research object's contents -- validating that other properties hold. |
+| **[D]({{< ref "stamped_principles/d" >}})** -- [Distributability]({{< ref "stamped_principles/d" >}}) | The research object and all its components are persistently retrievable by others, packaged like a software distribution. |
 
 These properties reinforce one another.
 Self-containment makes portability practical, tracking enables actionability,

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -33,8 +33,8 @@ beyond any single tool:
 
 Examples on this site are organized along four independent dimensions:
 
-1. **[STAMPED properties]({{< ref "stamped_principles" >}})** -- [Self-contained]({{< ref "stamped_principles/s" >}}), [Tracked]({{< ref "stamped_principles/t" >}}), [Actionable]({{< ref "stamped_principles/a" >}}),
-   [Modular]({{< ref "stamped_principles/m" >}}), [Portable]({{< ref "stamped_principles/p" >}}), [Ephemeral]({{< ref "stamped_principles/e" >}}), and [Distributable]({{< ref "stamped_principles/d" >}}).
+1. **[STAMPED properties]({{< ref "stamped_principles" >}})** -- [Self-containment]({{< ref "stamped_principles/s" >}}), [Tracking]({{< ref "stamped_principles/t" >}}), [Actionability]({{< ref "stamped_principles/a" >}}),
+   [Modularity]({{< ref "stamped_principles/m" >}}), [Portability]({{< ref "stamped_principles/p" >}}), [Ephemerality]({{< ref "stamped_principles/e" >}}), and [Distributability]({{< ref "stamped_principles/d" >}}).
 2. **[FAIR mapping]({{< ref "fair_principles" >}})** -- which of the FAIR goals ([Findable]({{< ref "fair_principles/f" >}}), [Accessible]({{< ref "fair_principles/a" >}}),
    [Interoperable]({{< ref "fair_principles/i" >}}), [Reusable]({{< ref "fair_principles/r" >}})) the practice supports.
 3. **[Instrumentation level]({{< ref "instrumentation_levels" >}})** -- ranging from [conventions]({{< ref "instrumentation_levels/data-organization" >}}) that require no

--- a/content/examples/container-venv-overlay-development.md
+++ b/content/examples/container-venv-overlay-development.md
@@ -405,7 +405,7 @@ reuse ([FAIR R]({{< ref "fair_principles/r" >}})) at scale.
 
 | Property | How the pattern embodies it |
 |---|---|
-| [Self-contained]({{< ref "stamped_principles/s" >}}) | `pyproject.toml` declares all dependencies; combined with a pinned container tag (or digest), the full environment is specified |
-| [Actionable]({{< ref "stamped_principles/a" >}}) | A single `docker run` or `singularity exec` command reproduces the environment — no manual setup steps |
-| [Portable]({{< ref "stamped_principles/p" >}}) | The container pins the Python version and system libraries; `pyproject.toml` (or a lock file) pins package versions; the pattern works on any host with a container runtime |
-| [Ephemeral]({{< ref "stamped_principles/e" >}}) | Each container invocation starts from a clean base; the overlay venv can be ephemeral (Scenario 3 — recreated every run for guaranteed reproducibility) or persistent (Scenarios 1–2 — kept across runs for faster iteration) — the choice is yours |
+| [Self-containment]({{< ref "stamped_principles/s" >}}) | `pyproject.toml` declares all dependencies; combined with a pinned container tag (or digest), the full environment is specified |
+| [Actionability]({{< ref "stamped_principles/a" >}}) | A single `docker run` or `singularity exec` command reproduces the environment — no manual setup steps |
+| [Portability]({{< ref "stamped_principles/p" >}}) | The container pins the Python version and system libraries; `pyproject.toml` (or a lock file) pins package versions; the pattern works on any host with a container runtime |
+| [Ephemerality]({{< ref "stamped_principles/e" >}}) | Each container invocation starts from a clean base; the overlay venv can be ephemeral (Scenario 3 — recreated every run for guaranteed reproducibility) or persistent (Scenarios 1–2 — kept across runs for faster iteration) — the choice is yours |

--- a/content/examples/ephemeral-shell-reproducer.md
+++ b/content/examples/ephemeral-shell-reproducer.md
@@ -157,11 +157,11 @@ exact, reproducible state of every dependency.
 
 | Property | How the pattern embodies it |
 |---|---|
-| [Self-contained]({{< ref "stamped_principles/s" >}}) | Everything needed is created inline — no external state required beyond the tool under test |
-| [Tracked]({{< ref "stamped_principles/t" >}}) | The script *is* the record: copy-pasteable into an issue, attachable to a commit |
-| [Actionable]({{< ref "stamped_principles/a" >}}) | Running the script *is* the reproduction — it is an executable specification of the bug, not a prose description |
-| [Portable]({{< ref "stamped_principles/p" >}}) | POSIX sh + `mktemp` + `${TMPDIR:-/tmp}` works across Linux and macOS; explicit `PS4` avoids shell-specific trace behavior; no hardcoded paths |
-| [Ephemeral]({{< ref "stamped_principles/e" >}}) | Each run operates in a fresh temp directory; the entire workspace can be discarded after inspection |
+| [Self-containment]({{< ref "stamped_principles/s" >}}) | Everything needed is created inline — no external state required beyond the tool under test |
+| [Tracking]({{< ref "stamped_principles/t" >}}) | The script *is* the record: copy-pasteable into an issue, attachable to a commit |
+| [Actionability]({{< ref "stamped_principles/a" >}}) | Running the script *is* the reproduction — it is an executable specification of the bug, not a prose description |
+| [Portability]({{< ref "stamped_principles/p" >}}) | POSIX sh + `mktemp` + `${TMPDIR:-/tmp}` works across Linux and macOS; explicit `PS4` avoids shell-specific trace behavior; no hardcoded paths |
+| [Ephemerality]({{< ref "stamped_principles/e" >}}) | Each run operates in a fresh temp directory; the entire workspace can be discarded after inspection |
 
 ## From reproducer to test case
 

--- a/content/examples/stellar-distance-walkthrough.md
+++ b/content/examples/stellar-distance-walkthrough.md
@@ -45,7 +45,7 @@ No new frameworks.
 No heavyweight infrastructure.
 Just a series of small, practical steps, each one solving a concrete problem: "which version of the data did I use?", "why doesn't this run on my colleague's laptop?", "how do I prove these numbers are right?"
 
-Along the way, we note which [STAMPED]({{< ref "stamped_principles" >}}) properties (Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, Distributable) each step improves.
+Along the way, we note which [STAMPED]({{< ref "stamped_principles" >}}) properties (Self-containment, Tracking, Actionability, Modularity, Portability, Ephemerality, Distributability) each step improves.
 By the end, we have a research object that passes a from-scratch reproduction test in a throwaway directory.
 Most of the steps turn out to be things we might already be doing, just named and organized.
 

--- a/content/stamped_principles/_index.md
+++ b/content/stamped_principles/_index.md
@@ -8,23 +8,23 @@ reproducible research object. The framework originates from the YODA principles
 and is described in full in the
 [STAMPED paper](https://github.com/stamped-principles/stamped-paper).
 
-- **S -- [Self-contained](s/)**: All modules and components essential to
+- **S -- [Self-containment](s/)**: All modules and components essential to
   replicate results are within a single top-level boundary.
 
-- **T -- [Tracked](t/)**: All components are content-addressed; provenance of
+- **T -- [Tracking](t/)**: All components are content-addressed; provenance of
   every modification is recorded.
 
-- **A -- [Actionable](a/)**: Procedures are executable specifications, not just
+- **A -- [Actionability](a/)**: Procedures are executable specifications, not just
   documentation. A cross-cutting property that applies to every other dimension.
 
-- **M -- [Modular](m/)**: Components are organized as independently versioned
+- **M -- [Modularity](m/)**: Components are organized as independently versioned
   modules that can be composed and reused.
 
-- **P -- [Portable](p/)**: Procedures do not depend on undocumented host state;
+- **P -- [Portability](p/)**: Procedures do not depend on undocumented host state;
   environments are explicitly specified and versioned.
 
-- **E -- [Ephemeral](e/)**: Results can be produced in temporary, disposable
+- **E -- [Ephemerality](e/)**: Results can be produced in temporary, disposable
   environments built solely from the research object's contents.
 
-- **D -- [Distributable](d/)**: The research object and all its components are
+- **D -- [Distributability](d/)**: The research object and all its components are
   persistently retrievable, packaged like a software distribution.

--- a/content/stamped_principles/a/_index.md
+++ b/content/stamped_principles/a/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "A — Actionable"
+title: "A — Actionability"
 description: "Procedures are executable specifications, not just documentation"
 ---
 

--- a/content/stamped_principles/d/_index.md
+++ b/content/stamped_principles/d/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "D — Distributable"
+title: "D — Distributability"
 description: "The research object and all its components are persistently retrievable by others"
 ---
 

--- a/content/stamped_principles/e/_index.md
+++ b/content/stamped_principles/e/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "E — Ephemeral"
+title: "E — Ephemerality"
 description: "Results produced in temporary, disposable environments validate that other STAMPED properties hold"
 ---
 

--- a/content/stamped_principles/m/_index.md
+++ b/content/stamped_principles/m/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "M — Modular"
+title: "M — Modularity"
 description: "Components organized as independently versioned modules that can be composed and reused"
 ---
 

--- a/content/stamped_principles/p/_index.md
+++ b/content/stamped_principles/p/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "P — Portable"
+title: "P — Portability"
 description: "Procedures do not depend on undocumented host state; environments are explicitly specified"
 ---
 

--- a/content/stamped_principles/s/_index.md
+++ b/content/stamped_principles/s/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "S — Self-contained"
+title: "S — Self-containment"
 description: "All essential modules and components reside within a single top-level boundary"
 ---
 

--- a/content/stamped_principles/t/_index.md
+++ b/content/stamped_principles/t/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "T — Tracked"
+title: "T — Tracking"
 description: "Version information and provenance recorded for all components via content-addressed version control"
 ---
 


### PR DESCRIPTION
## Summary

The [STAMPED paper](https://github.com/stamped-principles/stamped-paper/blob/main/main.tex) now defines the principles as nouns — Self-containment, Tracking, Actionability, Modularity, Portability, Ephemerality, Distributability. This updates the site to match.

Only principle **names** change. Descriptive adjectives are left as-is (e.g. "the script is self-contained"), matching the paper's convention of adjectives for describing a research object and nouns for naming a principle.

## Changes (13 files)

- Taxonomy term pages and landing under `content/stamped_principles/`.
- Homepage STAMPED table and about-page list.
- Principle names in the examples.

Single-letter taxonomy codes in example front matter are untouched, so example→term associations are preserved.

## Test plan

- [x] `hugo --gc` builds clean (130 pages, 0 errors — a broken `ref` would fail the build).
- [x] All 7 term pages render the new noun-form heading and still list their examples.
